### PR TITLE
statically link C runtime library

### DIFF
--- a/Spore ModAPI/Spore ModAPI.vcxproj
+++ b/Spore ModAPI/Spore ModAPI.vcxproj
@@ -104,6 +104,7 @@
       <SDLCheck>true</SDLCheck>
       <DisableSpecificWarnings>4351</DisableSpecificWarnings>
       <PreprocessToFile>false</PreprocessToFile>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -126,6 +127,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <DisableSpecificWarnings>4351</DisableSpecificWarnings>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -149,6 +151,7 @@
       <DisableSpecificWarnings>4351</DisableSpecificWarnings>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <AdditionalOptions>/d1reportSingleClassLayoutcBuildingBase %(AdditionalOptions)</AdditionalOptions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -174,6 +177,7 @@
       <DisableSpecificWarnings>4351</DisableSpecificWarnings>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <AdditionalOptions>/d1reportSingleClassLayoutcBuildingBase %(AdditionalOptions)</AdditionalOptions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
When you look at the DLL dependencies, you'll see the following:
```
>dumpbin /dependents .\SporeModAPI.dll
Microsoft (R) COFF/PE Dumper Version 14.30.30705.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file .\SporeModAPI.dll

File Type: DLL

  Image has the following dependencies:

    KERNEL32.dll
    USER32.dll
    VCRUNTIME140.dll
    api-ms-win-crt-heap-l1-1-0.dll
    api-ms-win-crt-runtime-l1-1-0.dll
    api-ms-win-crt-math-l1-1-0.dll

  Summary

       13000 .data
       19000 .rdata
        1000 .reloc
        1000 .rsrc
        9000 .text

```


I think it'd be better to not rely on the C runtime libraries, so with this PR the output changes to:
```
>dumpbin /dependents .\SporeModAPI.dll
Microsoft (R) COFF/PE Dumper Version 14.30.30705.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file .\SporeModAPI.dll

File Type: DLL

  Image has the following dependencies:

    KERNEL32.dll
    USER32.dll

  Summary

       14000 .data
       20000 .rdata
        2000 .reloc
        1000 .rsrc
       16000 .text
```

Also see the documentation about the option: https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library