### PR TITLE
Added `JumpToAct()` (Disc address: `0xF1F7B0`) to `cScenarioPlayMode`

### DIFF
--- a/Projects/Example Projects/ModCreatorKit/PackageCheat.cpp
+++ b/Projects/Example Projects/ModCreatorKit/PackageCheat.cpp
@@ -15,7 +15,7 @@ void PrintPackages() {
 	int count = ResourceManager.GetDatabaseList(databases);
 	App::ConsolePrintF("----- %d databases:", count);
 	for (auto database : databases) {
-		App::ConsolePrintF("ls", database->GetLocation());
+		App::ConsolePrintF("%ls", database->GetLocation());
 	}
 	App::ConsolePrintF("-----");
 }

--- a/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
+++ b/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
@@ -733,6 +733,7 @@ namespace Simulator
 	namespace Addresses(cScenarioPlayMode)
 	{
 		DefineAddress(SetCurrentAct, SelectAddress(0xF1F260, 0xF1EE70));
+		DefineAddress(JumpToAct, SelectAddress(0xF1F7B0, 0xF1F3C0));
 	}
 
 	namespace Addresses(cPlanetRecord)

--- a/Spore ModAPI/SourceCode/Simulator/Scenario.cpp
+++ b/Spore ModAPI/SourceCode/Simulator/Scenario.cpp
@@ -72,5 +72,6 @@ namespace Simulator
 
 
 	auto_METHOD_VOID(cScenarioPlayMode, SetCurrentAct, Args(int index, bool arg), Args(index, arg));
+	auto_METHOD_VOID(cScenarioPlayMode, JumpToAct, Args(int actIndex), Args(actIndex));
 }
 #endif

--- a/Spore ModAPI/Spore/Simulator/cScenarioPlayMode.h
+++ b/Spore ModAPI/Spore/Simulator/cScenarioPlayMode.h
@@ -57,6 +57,7 @@ namespace Simulator
 		//TODO check sub_F1EFC0
 		
 		void SetCurrentAct(int actIndex, bool = false);
+		void JumpToAct(int actIndex);
 
 	public:
 		/* 0Ch */	cScenarioPlaySummary mSummary;


### PR DESCRIPTION
This pull request adds a new member function for `cScenarioPlayMode` with address `0xF1F7B0` (Disc) / `0xF1F3C0` (March 2017) to the SDK, which is what is called when you use the arrow buttons found on top of the mission bar of Adventure Editor's test play mode. It skips the adventure's progress over to the act defined by the integer argument `actIndex`, completing all of the goals preceding that act and automatically warping the player to the last position they should be in according to the previous act's goal markers.

As an extra, this pull request also fixes the issue mentioned in #39, making it so the `devPackage` cheat found in the ModCreatorKit actually lists all of the databases found in-game, instead of a wall of `ls` strings.