### PR TITLE
Add a Log system for mods.

### DIFF
--- a/Spore ModAPI/SourceCode/App/App.cpp
+++ b/Spore ModAPI/SourceCode/App/App.cpp
@@ -1,3 +1,4 @@
+
 #ifndef MODAPI_DLL_EXPORT
 #include <Spore\App\Thumbnail_cImportExport.h>
 #include <Spore\App\AppData.h>
@@ -6,9 +7,12 @@
 #include <Spore\App\cSporeApp.h>
 #include <Spore\App\cArithmeticaResource.h>
 #include <Spore\App\ConfigManager.h>
+#endif
+#include <Spore\App\CommandLine.h>
 
 namespace App
 {
+#ifndef MODAPI_DLL_EXPORT
 	auto_STATIC_METHOD_(Thumbnail_cImportExport, Thumbnail_cImportExport*, Get);
 
 	auto_METHOD(Thumbnail_cImportExport, bool, GetFolderPath,
@@ -38,6 +42,8 @@ namespace App
 	auto_STATIC_METHOD_VOID_(cSporeApp, Run);
 	auto_STATIC_METHOD_(cSporeApp, bool, Shutdown);
 
+	auto_STATIC_METHOD_(Canvas, Canvas*, Get);
+#endif
 
 	auto_METHOD(CommandLine, eastl::string16&, Get, Args(int i), Args(i));
 
@@ -90,4 +96,3 @@ namespace App
 		return *(PropertyList**)GetAddress(App, sPreferencesPropList);
 	}
 }
-#endif

--- a/Spore ModAPI/SourceCode/App/App.cpp
+++ b/Spore ModAPI/SourceCode/App/App.cpp
@@ -34,26 +34,12 @@ namespace App
 
 	auto_STATIC_METHOD_(cCreatureModeStrategy, cCreatureModeStrategy*, Get);
 
-
 	auto_STATIC_METHOD_(IAppSystem, IAppSystem*, Get);
 
 	auto_STATIC_METHOD(cSporeApp, int, EAMain, Args(CommandLine* commandLine), Args(commandLine));
 	auto_STATIC_METHOD(cSporeApp, bool, Init, Args(CommandLine* commandLine), Args(commandLine));
 	auto_STATIC_METHOD_VOID_(cSporeApp, Run);
 	auto_STATIC_METHOD_(cSporeApp, bool, Shutdown);
-
-	auto_STATIC_METHOD_(Canvas, Canvas*, Get);
-#endif
-
-	auto_METHOD(CommandLine, eastl::string16&, Get, Args(int i), Args(i));
-
-	auto_METHOD(CommandLine, int, FindSwitch,
-		Args(const char16_t* a1, bool a2, eastl::string16* a3, int a4),
-		Args(a1, a2, a3, a4));
-
-	CommandLine* GetAppCommandLine() {
-		return *(CommandLine**)GetAddress(App, sAppCommandLine);
-	}
 
 	auto_STATIC_METHOD_(Canvas, Canvas*, Get);
 
@@ -86,7 +72,6 @@ namespace App
 	void cArithmeticaResource::func14h() {
 	}
 
-
 	//// ConfigManager ////
 
 	auto_STATIC_METHOD_(IConfigManager, IConfigManager*, Get);
@@ -94,5 +79,16 @@ namespace App
 	PropertyList* GetPreferences()
 	{
 		return *(PropertyList**)GetAddress(App, sPreferencesPropList);
+	}
+#endif
+
+	auto_METHOD(CommandLine, eastl::string16&, Get, Args(int i), Args(i));
+
+	auto_METHOD(CommandLine, int, FindSwitch,
+		Args(const char16_t* a1, bool a2, eastl::string16* a3, int a4),
+		Args(a1, a2, a3, a4));
+
+	CommandLine* GetAppCommandLine() {
+		return *(CommandLine**)GetAddress(App, sAppCommandLine);
 	}
 }

--- a/Spore ModAPI/SourceCode/DLL/Application.cpp
+++ b/Spore ModAPI/SourceCode/DLL/Application.cpp
@@ -142,7 +142,7 @@ void CreateLogFile() {
 	log_path.resize(log_path.find_last_of('\\')+1);
 
 	eastl::string16 log_file_name;
-	AppCommandLine.FindSwitch(u"logfilename", false, &log_file_name);
+	AppCommandLine.FindSwitch(u"modapi-log-filename", false, &log_file_name);
 	if (log_file_name.empty())
 		log_file_name = u"spore_log";
 	log_file_name += u".txt";

--- a/Spore ModAPI/SourceCode/DLL/Application.h
+++ b/Spore ModAPI/SourceCode/DLL/Application.h
@@ -12,6 +12,8 @@
 #include <Spore\CommonIDs.h>
 #include <Spore\Messaging.h>
 #include <Spore\Cheats.h>
+#include <Spore\IO.h>
+#include <ctime>
 
 virtual_detour(ShaderFragments_detour, Graphics::cMaterialManager, Graphics::IMaterialManager, bool(Resource::Database*)) {};
 
@@ -23,6 +25,9 @@ namespace ModAPI
 	extern eastl::fixed_vector<InitFunction, MAX_MODS> disposeFunctions;
 
 	extern eastl::fixed_map<uint32_t, ISimulatorStrategyPtr, MAX_MODS> simulatorStrategies;
+
+	extern FileStreamPtr logFile;
+	extern __time64_t logFileStartTime;
 
 	long AttachDetour();
 	void DetachDetour();

--- a/Spore ModAPI/SourceCode/DLL/DllModAPI.cpp
+++ b/Spore ModAPI/SourceCode/DLL/DllModAPI.cpp
@@ -28,6 +28,45 @@ namespace ModAPI
 		disposeFunctions.push_back(f);
 	}
 
+	static constexpr unsigned int SCRATCH_SIZE = 4096;
+	char logScratch[SCRATCH_SIZE];
+
+	void Log(const char* fmt, ...) {
+		unsigned int offset = 0;
+		
+		__time64_t long_time;
+		_time64(&long_time);
+
+		long_time -= logFileStartTime;
+
+		constexpr static char formatted[] = {"[00:00:00]: "};
+		constexpr char format[] = {"[%02d:%02d:%02d]: "};
+		const int secs = long_time % 60;
+		long_time /= 60;
+		const int mins = long_time % 60;
+		long_time /= 60;
+		const int hours = long_time % 24;
+
+		sprintf_s(logScratch + offset, SCRATCH_SIZE - offset, format, hours,mins,secs);
+		offset += (sizeof(formatted)-1)/sizeof(formatted[0]);
+
+		va_list argList;
+		va_start(argList, fmt);
+		vsnprintf(logScratch + offset, SCRATCH_SIZE - offset, fmt, argList);
+		va_end(argList);
+
+		// vsnprintf does not guarantee a null terminator if the formatted string exceeds the buffer size
+		logScratch[SCRATCH_SIZE - 1] = 0;
+
+		if (logFile)
+		{
+			logFile->Write(logScratch, strlen(logScratch));
+			logFile->Write("\n", 1);
+			logFile->Flush();
+		}
+		App::ConsolePrintF(logScratch + offset);
+	}
+
 	bool AddSimulatorStrategy(Simulator::ISimulatorStrategy* strategy, uint32_t id) {
 		if (strategy && simulatorStrategies.find(id) == simulatorStrategies.end()) {
 			simulatorStrategies[id] = strategy;

--- a/Spore ModAPI/SourceCode/IO/StreamDefinitions.cpp
+++ b/Spore ModAPI/SourceCode/IO/StreamDefinitions.cpp
@@ -60,7 +60,6 @@ namespace IO
 	/////////////////////////
 }
 
-#ifndef MODAPI_DLL_EXPORT
 namespace IO
 {
 	//////////////////////
@@ -125,7 +124,8 @@ namespace IO
 	auto_METHOD(FileStream, size_t, GetPathCString, Args(char* pPath8, size_t nPathLength), Args(pPath8, nPathLength));
 	auto_METHOD(FileStream, bool, Open, Args(AccessFlags nAccessFlags, CD nCreationDisposition, int nSharing, int nUsageHints), Args(nAccessFlags, nCreationDisposition, nSharing, nUsageHints));
 
-
+	
+#ifndef MODAPI_DLL_EXPORT
 	//////////////////////
 
 
@@ -395,5 +395,5 @@ namespace IO
 	auto_METHOD(StreamNull, int, Write, Args(const void* pData, size_t nSize), Args(pData, nSize));
 
 	//////////////////////
-}
 #endif
+}

--- a/Spore ModAPI/Spore/ModAPI.h
+++ b/Spore ModAPI/Spore/ModAPI.h
@@ -20,6 +20,8 @@ namespace ModAPI
 	extern MODAPI void AddPostInitFunction(InitFunction);
 	extern MODAPI void AddDisposeFunction(InitFunction);
 
+	extern MODAPI void Log(const char* fmt, ...);
+
 	extern MODAPI bool AddSimulatorStrategy(Simulator::ISimulatorStrategy* strategy, uint32_t id);
 
 	extern MODAPI GameType GetGameType();


### PR DESCRIPTION
Mods can use ModAPI::Log(const char* fmt, ...); to log to a log file that is created at every launch of the game.

Currently this log file is created with the name spore_log.txt right next to the Spore ModAPI Launcher.exe.
I'm not convinced this is the right location, so I'm happy for further discussion in regards to that.

Secondly, I had to do what I believe is a nasty hack in order to get the DLLs to compile since FileStream's constructor was defined out for the DLL build, please let me know the correct way to resolve this.