### PR TITLE
New `Thumbnail_cImportExport` function and expanded `cScenarioPlayMode` documentation

### DIFF
--- a/Spore ModAPI/SourceCode/App/App.cpp
+++ b/Spore ModAPI/SourceCode/App/App.cpp
@@ -22,6 +22,8 @@ namespace App
 			bool forceReplace, bool disableSteganography),
 		Args(pResource, pImage, pDBPF, forceReplace, disableSteganography));
 
+	auto_METHOD(Thumbnail_cImportExport, bool, ReadPNG,
+		Args(const char16_t* path, ResourceKey& key), Args(path, key));
 
 
 	auto_STATIC_METHOD_(cIDGenerator, cIDGenerator*, Get);

--- a/Spore ModAPI/SourceCode/App/App.cpp
+++ b/Spore ModAPI/SourceCode/App/App.cpp
@@ -22,7 +22,7 @@ namespace App
 			bool forceReplace, bool disableSteganography),
 		Args(pResource, pImage, pDBPF, forceReplace, disableSteganography));
 
-	auto_METHOD(Thumbnail_cImportExport, bool, ReadPNG,
+	auto_METHOD(Thumbnail_cImportExport, bool, ImportPNG,
 		Args(const char16_t* path, ResourceKey& key), Args(path, key));
 
 

--- a/Spore ModAPI/SourceCode/DLL/AddressesApp.cpp
+++ b/Spore ModAPI/SourceCode/DLL/AddressesApp.cpp
@@ -405,7 +405,7 @@ namespace App
 		DefineAddress(GetFolderPath, SelectAddress(0x5F9140, 0x5F92C0));
 		DefineAddress(FolderPathFromLocale, SelectAddress(0x5F9220, 0x5F93A0));
 		DefineAddress(SavePNG, SelectAddress(0x5FA7E0, 0x5FA960));
-		DefineAddress(ReadPNG, SelectAddress(0x5FC240, 0x5FC3C0));
+		DefineAddress(ImportPNG, SelectAddress(0x5FC240, 0x5FC3C0));
 	}
 
 	namespace Addresses(cLocaleManager)

--- a/Spore ModAPI/SourceCode/DLL/AddressesApp.cpp
+++ b/Spore ModAPI/SourceCode/DLL/AddressesApp.cpp
@@ -405,6 +405,7 @@ namespace App
 		DefineAddress(GetFolderPath, SelectAddress(0x5F9140, 0x5F92C0));
 		DefineAddress(FolderPathFromLocale, SelectAddress(0x5F9220, 0x5F93A0));
 		DefineAddress(SavePNG, SelectAddress(0x5FA7E0, 0x5FA960));
+		DefineAddress(ReadPNG, SelectAddress(0x5FC240, 0x5FC3C0));
 	}
 
 	namespace Addresses(cLocaleManager)

--- a/Spore ModAPI/Spore/App/Thumbnail_cImportExport.h
+++ b/Spore ModAPI/Spore/App/Thumbnail_cImportExport.h
@@ -56,7 +56,7 @@ namespace App
 		/// @param path The full path to the file being read.
 		/// @param key Resource key to the creation being read.
 		/// @returns 'true' on success, 'false' if something failed.
-		bool ReadPNG(const char16_t* path, ResourceKey& key);
+		bool ImportPNG(const char16_t* path, ResourceKey& key);
 
 		static Thumbnail_cImportExport* Get();
 
@@ -77,6 +77,6 @@ namespace App
 		DeclareAddress(GetFolderPath);
 		DeclareAddress(FolderPathFromLocale);
 		DeclareAddress(SavePNG);
-		DeclareAddress(ReadPNG);
+		DeclareAddress(ImportPNG);
 	}
 }

--- a/Spore ModAPI/Spore/App/Thumbnail_cImportExport.h
+++ b/Spore ModAPI/Spore/App/Thumbnail_cImportExport.h
@@ -51,6 +51,13 @@ namespace App
 		bool SavePNG(Resource::ResourceObject* pResource, RenderWare::Raster* pImage, Resource::Database* database, 
 			bool forceReplace = false, bool disableSteganography = false);
 
+		/// Reads the PNG file from the given file path, and adds the creation found within to the Sporepedia if it hasn't been added yet. 
+		/// 
+		/// @param path The full path to the file being read.
+		/// @param key Resource key to the creation being read.
+		/// @returns 'true' on success, 'false' if something failed.
+		bool ReadPNG(const char16_t* path, ResourceKey& key);
+
 		static Thumbnail_cImportExport* Get();
 
 		// Not finished yet, but it's not important
@@ -70,5 +77,6 @@ namespace App
 		DeclareAddress(GetFolderPath);
 		DeclareAddress(FolderPathFromLocale);
 		DeclareAddress(SavePNG);
+		DeclareAddress(ReadPNG);
 	}
 }

--- a/Spore ModAPI/Spore/Simulator/SimulatorEnums.h
+++ b/Spore ModAPI/Spore/Simulator/SimulatorEnums.h
@@ -550,6 +550,26 @@ namespace Simulator
 		Defend = 11,
 	};
 
+	///  The different states in which an adventure can be while being played (beginning, active, completed, failed etc).
+	///  Used by Simulator::cScenarioPlayMode.
+	enum class ScenarioPlayModeState : int
+	{
+		/// When beginning adventure from the editor, it will skip the opening cinematic to immediately begin the adventure.
+		EditorStart = 0,
+		/// When the opening cinematic is running.
+		OpeningCinematic = 1,
+		/// When loading the adventure from quick play or (presumably) space stage. Opening cinematic will run.
+		MissionStart = 2,
+		/// The adventure is currently active.
+		Active = 3,
+		/// When the adventure is completed successfully, the victory cinematic will play and Spore points will be rewarded (if eligible). 
+		/// If applicable, the player captain will act joyful and perhaps dance in the results screen as Spore points are rewarded to them.
+		Completed = 5,
+		/// If the adventure wasn't successfully cleared, the failure or death cinematic will play, depending on the type of failure. 
+		/// Spore points will not be rewarded, and if applicable, the player captain will appear sad in the results screen.
+		Failed = 6
+
+	};
 	/// Possible motive (health & hunger) states for a creature; what is considered "low" and "critical" depends on the `MotiveTuning` settings
 	enum class CreatureMotive : int
 	{

--- a/Spore ModAPI/Spore/Simulator/cScenarioPlayMode.h
+++ b/Spore ModAPI/Spore/Simulator/cScenarioPlayMode.h
@@ -67,13 +67,11 @@ namespace Simulator
 		/* 64h */	eastl::vector<cScenarioPlayModeGoal> mCurrentGoals;
 		/* 78h */	int field_78;  // not initialized
 		/* 7Ch */	App::MessageListenerData mMessageListenerData;
-		/// Current gameplay state of the adventure.
+		/// Current state of the adventure play mode.
 		/// 0 is pre-init in editor play mode, 1 is intro, 2 seems to be pre-init in quick-play, 3 is gameplay, 5 is adventure completed and 6 is adventure failed (death or failed/invalid goals)
-		/// Not initialized
-		/* 90h */	int mCurrentGameplayState;
+		/* 90h */	ScenarioPlayModeState mCurrentPlayModeState; // not initialized
 		/// Controls what state the ending cinematic of the adventure is in. Set to 0 when ending procedure begins, 1 when cinematic activates, and 2 after player leaves the cinematic sequence.
-		/// Not initialized
-		/* 94h */	int mCurrentEndCinematicState; 
+		/* 94h */	int mCurrentEndCinematicState; // not initialized
 		/// The clock activates when mCurrentEndCinematicState is set to 0. It counts up to around 2000 units (milliseconds),  after which the ending cinematic activates and mCurrentEndCinematicState is set to 1.
 		/* 98h */	Clock mCinematicDelay;
 		/* B0h */	int field_B0;  // not initialized
@@ -85,15 +83,13 @@ namespace Simulator
 		/// The playtime of the current adventure in milliseconds. It pauses counting when the game is paused, and it records its count to display it at the results screen. 
 		/// If the adventure is shared, it will also be sent to the adventure's high scores in the Spore servers if the player is logged in.
 		/* C0h */	int mCurrentTimeMS;
-		/// The amount of Spore points the captain is rewarded at the end of a successful adventure. 
-		/// Not initialized.
-		/* C4h */	int mAdventurePoints;
+		/// The amount of Spore points the captain is rewarded at the end of a successful adventure.
+		/* C4h */	int mAdventurePoints; // not initialized
 		/* C8h */	int field_C8;  // not initialized
 		/* CCh */	int field_CC;  // not initialized
 		/* D0h */	int field_D0;  // not initialized
 		/// Index of the dialog box being displayed during talk-to goal cinematic (-1 is the initial fade-in + creature greeting animation, 0 is first dialog box, 1 is second etc.)
-		/// Not initialized
-		/* D4h */	int mCurrentDialogBoxIndex;  
+		/* D4h */	int mCurrentDialogBoxIndex;  // not initialized
 		/* D8h */	int field_D8;  // not initialized
 		/// Used for move-to goals. Distance of the nearest target to the player.
 		/* DCh */	float mDistanceToClosestMoveToTarget;

--- a/Spore ModAPI/Spore/Simulator/cScenarioPlayMode.h
+++ b/Spore ModAPI/Spore/Simulator/cScenarioPlayMode.h
@@ -67,9 +67,14 @@ namespace Simulator
 		/* 64h */	eastl::vector<cScenarioPlayModeGoal> mCurrentGoals;
 		/* 78h */	int field_78;  // not initialized
 		/* 7Ch */	App::MessageListenerData mMessageListenerData;
-		/* 90h */	int field_90;  // not initialized, current state? fail reason?
-		/* 94h */	int field_94;  // not initialized
-		/// The clock activates upon triggering the adventure's end. It counts up to around 2000 units (milliseconds),  after which the ending cinematic activates
+		/// Current gameplay state of the adventure.
+		/// 0 is pre-init in editor play mode, 1 is intro, 2 seems to be pre-init in quick-play, 3 is gameplay, 5 is adventure completed and 6 is adventure failed (death or failed/invalid goals)
+		/// Not initialized
+		/* 90h */	int mCurrentGameplayState;
+		/// Controls what state the ending cinematic of the adventure is in. Set to 0 when ending procedure begins, 1 when cinematic activates, and 2 after player leaves the cinematic sequence.
+		/// Not initialized
+		/* 94h */	int mCurrentEndCinematicState; 
+		/// The clock activates when mCurrentEndCinematicState is set to 0. It counts up to around 2000 units (milliseconds),  after which the ending cinematic activates and mCurrentEndCinematicState is set to 1.
 		/* 98h */	Clock mCinematicDelay;
 		/* B0h */	int field_B0;  // not initialized
 		/* B4h */	int field_B4;  // not initialized
@@ -86,16 +91,23 @@ namespace Simulator
 		/* C8h */	int field_C8;  // not initialized
 		/* CCh */	int field_CC;  // not initialized
 		/* D0h */	int field_D0;  // not initialized
-		/* D4h */	int field_D4;  // not initialized
+		/// Index of the dialog box being displayed during talk-to goal cinematic (-1 is the initial fade-in + creature greeting animation, 0 is first dialog box, 1 is second etc.)
+		/// Not initialized
+		/* D4h */	int mCurrentDialogBoxIndex;  
 		/* D8h */	int field_D8;  // not initialized
-		/* DCh */	float field_DC;
-		/* E0h */	Math::Vector3 field_E0;
+		/// Used for move-to goals. Distance of the nearest target to the player.
+		/* DCh */	float mDistanceToClosestMoveToTarget;
+		/// Coordinates of the move-to goal target's location.
+		/* E0h */	Math::Vector3 mMoveToGoalLocation;
 		/* ECh */	bool field_EC;
 		/* F0h */	Audio::AudioTrack mMusicTrack;
 		/* F4h */	uint32_t mCurrentMusicId;
-		/* F8h */	float field_F8;
-		/* FCh */	bool field_FC;
-		/* FDh */	bool field_FD;
+		/// The duration the captain fade-in effect is active during intro cutscene. Counts down to 0.
+		/* F8h */	float mIntroFadeinTimer;
+		/// Set to true when mIntroFadeinTimer begins counting. Set to false when mIntroBeamdownTimer is less than or equal to 0. 
+		/* FCh */	bool mIsIntroFadeinActive;
+		/// Initially set to false but set to true when adventure begins.
+		/* FDh */	bool mIsAdventureActive;
 		/* 100h */	int field_100;
 	};
 	ASSERT_SIZE(cScenarioPlayMode, 0x108);


### PR DESCRIPTION
Added one of the functions mentioned in issue #44 (Address: 0x5FC240 [Disk], 0x5FC3C0 [March 2017]), and named and documented more of class cScenarioPlayMode's fields.

The new function is a member of Thumbnail_cImportExport, and it reads PNG files from the filepath it receives as one argument. If a record of the creation doesn't yet exist in the game, it is added to the Sporepedia as a recently downloaded creation. In particular, it is called when new creations are added to the game via My Spore Creations (theoretically on game launch) and when files are dragged into the game window.