### PR TITLE
SDKtoGhidra: support Ghidra 10.3

### DIFF
--- a/SDKtoGhidra/GhidraScript/ImportSporeSDK.java
+++ b/SDKtoGhidra/GhidraScript/ImportSporeSDK.java
@@ -572,30 +572,7 @@ public class ImportSporeSDK extends GhidraScript {
 	}
 
     private static String getCallingConvention(Function function, FunctionSignature signature, CompilerSpec compilerSpec) {
-        boolean preserveCallingConvention = false;
-		PrototypeModel preferredModel = null;
-		if (signature.getGenericCallingConvention() != GenericCallingConvention.unknown) {
-			preferredModel = compilerSpec.matchConvention(signature.getGenericCallingConvention());
-		}
-
-		PrototypeModel convention = function.getCallingConvention();
-		if (convention == null || !preserveCallingConvention) {
-			convention = preferredModel;
-// NOTE: This has been disable since it can cause imported signature information to be
-// ignored and overwritten by subsequent analysis
-//			if (convention == null && compilerSpec.getCallingConventions().length > 1) {
-//				// use default source for signature if convention is really unknown so that we
-//				// know dynamic storage assignment is unreliable
-//				source = SourceType.DEFAULT;
-//			}
-		}
-
-		// Calling convention is permitted to change
-		String conventionName = function.getCallingConventionName();
-		if (!preserveCallingConvention && convention != null) {
-			conventionName = convention.getName();
-		}
-		return conventionName;
+		return function.getCallingConventionName();
 	}
 
 


### PR DESCRIPTION
This patch makes the ImportSporeSDK.java script work with Ghidra 10.3.

It seems that since Ghidra 10.3 `getGenericCallingConvention` was removed causing an error when trying to run it:
```java
ImportSporeSDK.java:577: error: cannot find symbol
		if (signature.getGenericCallingConvention() != GenericCallingConvention.unknown) {
		             ^
  symbol:   method getGenericCallingConvention()
  location: variable signature of type ghidra.program.model.listing.FunctionSignature
ImportSporeSDK.java:578: error: cannot find symbol
			preferredModel = compilerSpec.matchConvention(signature.getGenericCallingConvention());
			                                                       ^
  symbol:   method getGenericCallingConvention()
  location: variable signature of type ghidra.program.model.listing.FunctionSignature
Note: ImportSporeSDK.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
skipping C:\Users\Rosalie\source\repos\SporeAutoSave\Spore-ModAPI\SDKtoGhidra\GhidraScript\ImportSporeSDK.java
> Unable to load script: ImportSporeSDK.java
>   detail: The class could not be found. It must be the public class of the .java file: ImportSporeSDK not found by c0d474ff [26]
```