### PR TITLE
Improve log file location detection

### DIFF
--- a/Spore ModAPI/Spore ModAPI.vcxproj
+++ b/Spore ModAPI/Spore ModAPI.vcxproj
@@ -104,6 +104,7 @@
       <SDLCheck>true</SDLCheck>
       <DisableSpecificWarnings>4351</DisableSpecificWarnings>
       <PreprocessToFile>false</PreprocessToFile>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -126,6 +127,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <DisableSpecificWarnings>4351</DisableSpecificWarnings>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -148,6 +150,7 @@
       <SDLCheck>true</SDLCheck>
       <DisableSpecificWarnings>4351</DisableSpecificWarnings>
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -172,6 +175,7 @@
       <SDLCheck>true</SDLCheck>
       <DisableSpecificWarnings>4351</DisableSpecificWarnings>
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
This patch fixes the following issues:
* Enables `MultiProcessorCompilation` for improved compilation times
* Improves log file location detection by checking if there's a parent process (using a whitelist of known executable names) and fall back to the Spore exe when we fail to do so (i.e when using SporeModLoader)
* Removes usage of `mbrtoc16` which hasn't been implemented in WINE and causes a crash when used, and replace the `char[]` usage with a `wchar_t[]`, which is UTF-16 on windows so `mbrtoc16` isn't needed as far as I know.