### PR TITLE
Add support for a unified DLL build

### DIFF
--- a/Spore ModAPI/Spore/Internal.h
+++ b/Spore ModAPI/Spore/Internal.h
@@ -43,6 +43,10 @@
 		#define SelectAddress(addressDisk, addressSteamPatched) addressDisk
 	#elif EXECUTABLE_TYPE == 2
 		#define SelectAddress(addressDisk, addressSteamPatched) addressSteamPatched
+	#elif EXECUTABLE_TYPE == 10
+		// forward declaration to prevent compilation errors
+		namespace ModAPI { extern MODAPI uintptr_t ChooseAddress(uintptr_t, uintptr_t); }
+		#define SelectAddress(addressDisk, addressSteamPatched) ModAPI::ChooseAddress(addressDisk, addressSteamPatched)
 	#endif
 #endif
 


### PR DESCRIPTION
This allows a mod loader to build a unified DLL which supports both disk and march2017 Spore.