### PR TITLE
cCity update

### DIFF
--- a/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
+++ b/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
@@ -23,6 +23,7 @@
 #include <Spore\Simulator\Cell\cCellUI.h>
 #include <Spore\Simulator\Cell\CellFunctions.h>
 #include <Spore\Simulator\cCreatureGameData.h>
+#include <Spore\Simulator\cCommunityLayout.h>
 #include <Spore\Simulator\cEmpire.h>
 #include <Spore\Simulator\cEnergyRepairToolStrategy.h>
 #include <Spore\Simulator\cGameDataUFO.h>
@@ -56,6 +57,7 @@
 #include <Spore\Simulator\cScenarioPowerup.h>
 #include <Spore\Simulator\cScenarioSimulator.h>
 #include <Spore\Simulator\cScenarioTerraformMode.h>
+#include <Spore\Simulator\cCultureSet.h>
 #include <Spore\Simulator\SubSystem\SpaceGfx.h>
 #include <Spore\Simulator\cHerd.h>
 #include <Spore\Simulator\cToolStrategy.h>
@@ -148,6 +150,9 @@ namespace Simulator
 	{
 		DefineAddress(IsAboveCity, SelectAddress(0xBD90C0, 0xBD9D50));
 		DefineAddress(SpawnVehicle, SelectAddress(0xBDD410, 0xBDDEF0));
+		DefineAddress(ProcessBuildingUpdate, SelectAddress(0xBE1C10, 0xBE2590));
+		DefineAddress(AddBuilding, SelectAddress(0xBE16C0, 0xBE2040));
+		DefineAddress(RemoveBuilding, SelectAddress(0xBE2B20, 0xBE34A0));
 	}
 
 	namespace Addresses(cCreatureAbility)
@@ -483,6 +488,8 @@ namespace Simulator
 
 		DefineAddress(UpdateModels, SelectAddress(0xB227E0, 0xB228F0));
 		DefineAddress(SetAvatar, SelectAddress(0xB1FB90, 0xB1FCA0));
+
+		DefineAddress(GetPlayerCivilization, SelectAddress(0xB25E30, 0xB25F90));
 	}
 
 	namespace Addresses(cGameViewManager)
@@ -946,6 +953,24 @@ namespace Simulator
 		DefineAddress(GetRareHasBeenFound, SelectAddress(0x103BC30, 0x103AC50));
 		DefineAddress(SetRareAsFound, SelectAddress(0x1040820, 0x103FBB0));
 		DefineAddress(GenerateNPCStore, SelectAddress(0x103F560, 0x103E8F0));
+	}
+
+	namespace Addresses(cCultureSet) 
+	{
+		DefineAddress(PickCreation, SelectAddress(0xBF8DF0, 0xBF9840));
+	}
+
+	namespace Addresses(cCommunityLayout)
+	{
+		DefineAddress(InitializeSlots, SelectAddress(0xAFE620, 0xAFEB80));
+		DefineAddress(SnapSlotsToPlanet, SelectAddress(0xAFA690, 0xAFAE40));
+		DefineAddress(SetParameters, SelectAddress(0xAF95D0, 0xAF9C70));
+	}
+
+	namespace Addresses(cLayoutSlot)
+	{
+		DefineAddress(SetObject, SelectAddress(0xAF9890, 0xAF9FB0));
+		DefineAddress(RemoveObject, SelectAddress(0xAF9900, 0xAFA020));
 	}
 }
 

--- a/Spore ModAPI/SourceCode/Simulator/GameNounManager.cpp
+++ b/Spore ModAPI/SourceCode/Simulator/GameNounManager.cpp
@@ -38,5 +38,7 @@ namespace Simulator
 	cTribe* cGameNounManager::GetPlayerTribe() {
 		return mpPlayerTribe.get();
 	}
+
+	auto_METHOD_(cGameNounManager, cCivilization*, GetPlayerCivilization);
 }
 #endif

--- a/Spore ModAPI/SourceCode/Simulator/cCity.cpp
+++ b/Spore ModAPI/SourceCode/Simulator/cCity.cpp
@@ -30,5 +30,23 @@ namespace Simulator
 	auto_METHOD(cCity, cVehicle*, SpawnVehicle, 
 		Args(VehiclePurpose speciality, VehicleLocomotion locomotion, struct ResourceKey key, bool isSpaceStage),
 		Args(speciality, locomotion, key, isSpaceStage));
+
+
+	auto_METHOD_VOID(cCity, AddBuilding, Args(cBuilding* a0, bool a1), Args(a0, a1));
+	auto_METHOD(cCity, bool, RemoveBuilding, Args(cBuilding* a0), Args(a0));
+
+	auto_STATIC_METHOD_VOID(cCity, ProcessBuildingUpdate, Args(cCity* a0, int a1, int a2), Args(a0, a1, a2));
+
+
+
+	auto_METHOD_VOID(cCommunityLayout, SetParameters, Args(const Math::Vector3& a0, float a1, const Math::Vector3& a2, float a3), Args(a0, a1, a2, a3));
+
+	auto_METHOD_VOID(cCommunityLayout, InitializeSlots, Args(const eastl::vector<Math::Vector3>& a0, float a1), Args(a0, a1));
+
+	auto_METHOD_VOID_(cCommunityLayout, SnapSlotsToPlanet);
+
+
+	auto_METHOD_VOID(cLayoutSlot, SetObject, Args(cGameData* obj), Args(obj));
+	auto_METHOD_VOID(cLayoutSlot, RemoveObject, Args(cGameData* obj), Args(obj));
 }
 #endif

--- a/Spore ModAPI/SourceCode/Simulator/cCultureSet.cpp
+++ b/Spore ModAPI/SourceCode/Simulator/cCultureSet.cpp
@@ -44,5 +44,7 @@ namespace Simulator
 			return nullptr;
 		}
 	}
+
+	auto_METHOD(cCultureSet, const ResourceKey&, PickCreation, Args(ModelTypes creationType), Args(creationType));
 }
 #endif

--- a/Spore ModAPI/Spore ModAPI.vcxproj
+++ b/Spore ModAPI/Spore ModAPI.vcxproj
@@ -401,9 +401,11 @@
     <ClInclude Include="Spore\Simulator\cBuildingIndustry.h" />
     <ClInclude Include="Spore\Simulator\cCombatSimulator.h" />
     <ClInclude Include="Spore\Simulator\cCommodityNode.h" />
+    <ClInclude Include="Spore\Simulator\cCommunityLayout.h" />
     <ClInclude Include="Spore\Simulator\cCreatureCitizen.h" />
     <ClInclude Include="Spore\Simulator\cCreatureDisplayStrategy.h" />
     <ClInclude Include="Spore\Simulator\cCreatureGameData.h" />
+    <ClInclude Include="Spore\Simulator\cCulturalTarget.h" />
     <ClInclude Include="Spore\Simulator\cEgg.h" />
     <ClInclude Include="Spore\Simulator\cEllipticalOrbit.h" />
     <ClInclude Include="Spore\Simulator\Cell\cCellGame.h" />
@@ -443,6 +445,7 @@
     <ClInclude Include="Spore\Simulator\cTribeHut.h" />
     <ClInclude Include="Spore\Simulator\cTribePlanner.h" />
     <ClInclude Include="Spore\Simulator\cTribeTool.h" />
+    <ClInclude Include="Spore\Simulator\cTurret.h" />
     <ClInclude Include="Spore\Simulator\ICityMusic.h" />
     <ClInclude Include="Spore\Simulator\cBadgeManager.h" />
     <ClInclude Include="Spore\Simulator\cMissionManager.h" />

--- a/Spore ModAPI/Spore ModAPI.vcxproj.filters
+++ b/Spore ModAPI/Spore ModAPI.vcxproj.filters
@@ -2130,6 +2130,15 @@
     <ClInclude Include="Spore\Simulator\SubSystem\SpaceTrading.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Spore\Simulator\cCommunityLayout.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Spore\Simulator\cCulturalTarget.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Spore\Simulator\cTurret.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="SourceCode\Allocator.cpp">

--- a/Spore ModAPI/Spore/Simulator/SubSystem/GameNounManager.h
+++ b/Spore ModAPI/Spore/Simulator/SubSystem/GameNounManager.h
@@ -110,6 +110,8 @@ namespace Simulator
 
 		cTribe* GetPlayerTribe();
 
+		cCivilization* GetPlayerCivilization();
+
 		/// Returns the active Simulator game noun manager.
 		static cGameNounManager* Get();
 			
@@ -151,6 +153,8 @@ namespace Simulator
 
 		DeclareAddress(UpdateModels);
 		DeclareAddress(SetAvatar);
+
+		DeclareAddress(GetPlayerCivilization);  // 0xB25E30 0xB25F90
 	}
 
 #ifndef SDK_TO_GHIDRA

--- a/Spore ModAPI/Spore/Simulator/cCityWalls.h
+++ b/Spore ModAPI/Spore/Simulator/cCityWalls.h
@@ -28,6 +28,8 @@ namespace Simulator
 {
 	class cCity;
 
+	constexpr int MAX_LAYOUT_SLOTS = 14;
+
 	class cCityWalls
 		/* 00h */	: public cGameData
 		/* 34h */	, public cSpatialObject
@@ -56,24 +58,39 @@ namespace Simulator
 		/* 150h */	int field_150;
 		/* 154h */	int field_154;
 		/* 158h */	int field_158;
-		/* 15Ch */	eastl::vector<int> field_15C;
-		/* 170h */	eastl::vector<int> field_170;
-		/* 184h */	eastl::vector<int> field_184;
-		/* 198h */	eastl::vector<int> field_198;
-		/* 1ACh */	eastl::vector<int> field_1AC;
-		/* 1C0h */	eastl::vector<int> field_1C0;
-		/* 1D4h */	eastl::vector<int> field_1D4;
-		/* 1E8h */	eastl::vector<int> field_1E8;
-		/* 1FCh */	eastl::vector<int> field_1FC;
-		/* 210h */	eastl::vector<int> field_210;
-		/* 224h */	Vector3 field_224[4];
+		/// From property `Turrets` 
+		/* 15Ch */	eastl::vector<Math::Vector3> mTurrets;
+		/// Positions from mTurrets transformed with the city position/rotation
+		/* 170h */	eastl::vector<Math::Vector3> mTurretsTransformed;
+		/// First is property `Main_Gate`, index 1 and 2 are property `Side_Gates`, index 3 is property `Sea_Gate`,
+		// index 4 is property `Harvest_Gate`, index 5 is `Freight_Gate`
+		/* 184h */	eastl::vector<Math::Vector3> mGates;
+		/// Positions from mGates transformed with the city position/rotation
+		/* 198h */	eastl::vector<Math::Vector3> mGatesTransformed;
+		/// First slot is `City_Hall`, the rest is `Buildings`
+		/* 1ACh */	eastl::vector<Math::Vector3> mBuildings;
+		/// Positions from mBuildings transformed with the city position/rotation
+		/* 1C0h */	eastl::vector<Math::Vector3> mBuildingsTransformed;
+		/// From property `Decorations`
+		/* 1D4h */	eastl::vector<Math::Vector3> mDecorations;
+		/// Positions from mDecorations transformed with the city position/rotation
+		/* 1E8h */	eastl::vector<Math::Vector3> mDecorationsTransformed;
+		/// From property `Plazas`
+		/* 1FCh */	eastl::vector<Math::Vector3> mPlazas;
+		/// Positions from mPlazas transformed with the city position/rotation
+		/* 210h */	eastl::vector<Math::Vector3> mPlazasTransformed;
+		/* 224h */	Vector3 mFirstBoatPos;
+		/* 230h */	Vector3 mFirstBoatPosTransformed;
+		/* 23Ch */	Vector3 mModelDocksOffset;
+		/* 248h */	Vector3 mModelDocksOffsetTransformed;
 		/* 254h */	int mWallSize;
-		/* 258h */	float field_258;  // 29
-		/* 25Ch */	float field_25C;  // 37  sphere radius?
-		/* 260h */	float field_260;
+		/* 258h */	float mInnerRadius;  // 29
+		/* 25Ch */	float mOuterRadius;  // 37  sphere radius?
+		/* 260h */	float mCityHallDiasHeight;
 		/* 264h */	eastl::intrusive_ptr<cCity> mpCity;
 		/* 268h */	Vector3 field_268;  // 1, 1, 1
-		/* 274h */	char field_274[0xC4];  // 14 booleans
+		/// A matrix teling which building slots are connected to which slots
+		/* 274h */	bool mBuildingLinks[MAX_LAYOUT_SLOTS][MAX_LAYOUT_SLOTS];
 		/* 338h */	Vector3 mCenterAxis;  // not initialized
 		/* 344h */	uint32_t mStyle;  // 0x9181A19
 		/* 348h */	int mLevel;

--- a/Spore ModAPI/Spore/Simulator/cCommunity.h
+++ b/Spore ModAPI/Spore/Simulator/cCommunity.h
@@ -21,6 +21,7 @@
 #include <Spore\Simulator\cGameData.h>
 #include <Spore\Simulator\cGonzagoTimer.h>
 #include <Spore\Simulator\cCreatureCitizen.h>
+#include <Spore\Simulator\cCityWalls.h>
 #include <Spore\Editors\INameableEntity.h>
 #include <Spore\MathUtils.h>
 #include <EASTL\vector.h>
@@ -74,7 +75,7 @@ namespace Simulator
 		/* 60h */	virtual float func60h();
 		/* 64h */	virtual Vector3& func64h();
 		/* 68h */	virtual void func68h();
-		/* 6Ch */	virtual int func6Ch();  // returns 0
+		/* 6Ch */	virtual cCityWalls* GetCityWalls();  // returns 0
 		/* 70h */	virtual eastl::vector<ObjectPtr>& GetPopulation();
 		/* 74h */	virtual int GetPopulationCount();  // returns the count of vector returned by func70h
 		/* 78h */	virtual void func78h(); 

--- a/Spore ModAPI/Spore/Simulator/cCommunityLayout.h
+++ b/Spore ModAPI/Spore/Simulator/cCommunityLayout.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <Spore\Simulator\cGameData.h>
+
+namespace Simulator
+{
+	struct cLayoutSlot 
+	{
+		void SetObject(cGameData* object);
+		void RemoveObject(cGameData* object);
+
+		/* 00h */	bool mIsOccupied;
+		/// A building, turret, ornament, etc
+		/* 04h */	cGameDataPtr mpObject;
+		/* 08h */	int field_8;
+		/* 0Ch */	Math::Vector3 mPosition;
+	};
+	ASSERT_SIZE(cLayoutSlot, 0x18);
+
+	namespace Addresses(cLayoutSlot)
+	{
+		DeclareAddress(SetObject);  // 0xAF9890 0xAF9FB0
+		DeclareAddress(RemoveObject);  // 0xAF9900 0xAFA020
+	}
+
+	/// Also used by Tribe, related with city layout
+	struct cCommunityLayout
+	{
+	public:
+		void SetParameters(const Math::Vector3& origin, float, const Math::Vector3& direction, float);
+
+		/// Initializes the layout with all empty slots, in the specified positions.
+		void InitializeSlots(const eastl::vector<Math::Vector3>& positions, float);
+
+		/// Moves all existing slots to be on the surface of the planet.
+		void SnapSlotsToPlanet();
+
+	public:
+		/// Local Y axis
+		/* 00h */	Vector3 mDirection;
+		/* 0Ch */	float field_C;  // -1.0
+		/* 10h */	float field_10;  // -1.0
+		/* 14h */	Vector3 mOrigin;
+		/* 20h */	float field_20;
+		/* 24h */	int field_24;  // not initialized
+		/* 28h */	bool field_28;
+		/* 2Ch */	Quaternion field_2C;
+		/* 3Ch */	eastl::vector<int> field_3C;
+		/* 50h */	eastl::vector<cLayoutSlot> mSlots;
+	};
+	ASSERT_SIZE(cCommunityLayout, 0x64);
+
+	namespace Addresses(cCommunityLayout) 
+	{
+		DeclareAddress(InitializeSlots);  // 0xAFE620 0xAFEB80
+		DeclareAddress(SnapSlotsToPlanet);  // 0xAFA690 0xAFAE40
+		DeclareAddress(SetParameters);  // 0xAF95D0 0xAF9C70
+	}
+}

--- a/Spore ModAPI/Spore/Simulator/cCreatureBase.h
+++ b/Spore ModAPI/Spore/Simulator/cCreatureBase.h
@@ -200,6 +200,7 @@ namespace Simulator
 		/* 6Ch */	virtual void func6Ch(int deltaTime);  // called by Update
 		/* 70h */	virtual void func70h(float deltaTimeSeconds);  // called by Update
 		/* 74h */	virtual void func74h(void*);  // related to babies growing up
+		/* 78h */	virtual void func78h();
 		/* 7Ch */	virtual float GetBaseMaxHitPoints() = 0;
 		/* 80h */	virtual float CalculateScale(bool isBaby);
 		/* 84h */	virtual void SetCreatureTarget(cCombatant* pTarget, bool, int intentionTowardsTarget);  //TODO check loc_D3242E

--- a/Spore ModAPI/Spore/Simulator/cCulturalTarget.h
+++ b/Spore ModAPI/Spore/Simulator/cCulturalTarget.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <Spore\Simulator\cGameData.h>
+#include <Spore\Simulator\cSpatialObject.h>
+#include <Spore\Simulator\cCombatant.h>
+#include <Spore\Simulator\cHitSphere.h>
+#include <Spore\Simulator\cVehicle.h>
+
+#define cCulturalTargetPtr eastl::intrusive_ptr<Simulator::cCulturalTarget>
+
+namespace Simulator
+{
+	class cCulturalTarget
+		/* 00h */	: public cGameData
+		/* 34h */	, public cCombatant
+		/* 100h */	, public cSpatialObject
+	{
+	public:
+		static const uint32_t TYPE = 0x3D5C477;
+		static const uint32_t NOUN_ID = 0x3D5C325;
+
+	public:
+		/* 1D4h */	int8_t mGateIndex;  // -1
+		/* 1D8h */	int mAttackState;
+		/* 1DCh */	uint32_t mAttackerPoliticalID;  // -1
+		/* 1E0h */	eastl::vector<int> field_1E0;
+		/* 1F4h */	eastl::vector<cVehiclePtr> mAttackers;
+		/* 208h */	cHitSpherePtr mpHitSphere;
+		/* 20Ch */	float field_20C;
+		/* 210h */	float field_210;
+		/* 214h */	int field_214;
+	};
+	ASSERT_SIZE(cCulturalTarget, 0x218);
+}

--- a/Spore ModAPI/Spore/Simulator/cCultureSet.h
+++ b/Spore ModAPI/Spore/Simulator/cCultureSet.h
@@ -42,9 +42,19 @@ namespace Simulator
 
 		const ResourceKey* GetCreation(ModelTypes creationType);
 
+		/// Returns the creation assigned to the specific type, or picks one randomly if there is no creation assigned yet.
+		/// @param creationType
+		const ResourceKey& PickCreation(ModelTypes creationType);
+
 		//TODO other methods such as sub_BF89F0, sub_BF8DF0
 
-	protected:
+	public:
 		eastl::map<uint32_t, ResourceKey> mModelTypeToKeyMap;
 	};
+	ASSERT_SIZE(cCultureSet, 0x1C);
+
+	namespace Addresses(cCultureSet) 
+	{
+		DeclareAddress(PickCreation);  // 0xBF8DF0 0xBF9840
+	}
 }

--- a/Spore ModAPI/Spore/Simulator/cTribe.h
+++ b/Spore ModAPI/Spore/Simulator/cTribe.h
@@ -11,6 +11,7 @@
 #include <Spore\Simulator\cTribeTool.h>
 #include <Spore\Simulator\cTribeFoodMat.h>
 #include <Spore\Simulator\cTotemPole.h>
+#include <Spore\Simulator\cCommunityLayout.h>
 #include <Spore\Simulator\cOrnament.h>
 #include <EASTL\fixed_vector.h>
 #include <EASTL\deque.h>
@@ -83,8 +84,8 @@ namespace Simulator
 		/* 368h */	cTribeHutPtr mpHut;
 		/* 36Ch */	eastl::vector<cTribeToolPtr> mTools;
 		/* 380h */	eastl::vector<cTribeToolPtr> mSocialTools;
-		/* 394h */	eastl::hash_map<int, UnkCityClass> field_394;
-		/* 3B4h */	UnkCityClass field_3B4;
+		/* 394h */	eastl::hash_map<int, cCommunityLayout> field_394;
+		/* 3B4h */	cCommunityLayout field_3B4;
 		/* 418h */	eastl::fixed_vector<int, 45> field_418;
 		/* 4E4h */	eastl::hash_map<int, eastl::deque<ObjectPtr>> field_4E4;
 		/* 504h */	int field_504;  // not initialized

--- a/Spore ModAPI/Spore/Simulator/cTurret.h
+++ b/Spore ModAPI/Spore/Simulator/cTurret.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <Spore\Simulator\cGameData.h>
+#include <Spore\Simulator\cLocomotiveObject.h>
+#include <Spore\Simulator\cBehaviorList.h>
+#include <Spore\Simulator\cBehaviorAgent.h>
+#include <Spore\Simulator\cSpaceToolData.h>
+#include <Spore\Simulator\cHitSphere.h>
+#include <Spore\Simulator\cCombatant.h>
+#include <Spore\Simulator\cPlaceableStructure.h>
+
+#define cTurretPtr eastl::intrusive_ptr<Simulator::cTurret>
+
+namespace Simulator
+{
+	class cCity;
+
+	class cTurret
+		/* 00h */	: public cGameData
+		/* 34h */	, public cLocomotiveObject
+		/* 504h */	, public cBehaviorList
+		/* 51Ch */	, public cBehaviorAgent
+		/* 588h */	, public cCombatant
+		/* 650h */	, public cPlaceableStructure
+	{
+	public:
+		static const uint32_t TYPE = 0x436F315;
+		static const uint32_t NOUN_ID = 0x436F342;
+	
+	public:
+		/* 658h */	char padding_658[8];
+		/* 660h */	cGonzagoTimer mDestroyTimer;
+		/* 680h */	int field_680;
+		/* 684h */	int mFreezeCount;
+		/* 688h */	eastl::intrusive_ptr<cCity> mpCity;
+		/* 68Ch */	cSpaceToolDataPtr mpWeapon;
+		/* 690h */	cSpaceToolDataPtr mpCivTurretWeapon;
+		/* 694h */	cSpaceToolDataPtr mpSpaceBeamWeapon;
+		/* 698h */	cSpaceToolDataPtr mpSpaceDefenseMissileWeapon;
+		/* 69Ch */	cSpaceToolDataPtr mpSpaceTurretFlak;
+		/* 6A0h */	cHitSpherePtr mpHitSphere;
+		/* 6A4h */	cCombatantPtr mpFacingTarget;
+		/* 6A8h */	int field_6A8;  // -1
+		/* 6B0h */	cGonzagoTimer field_6B0;
+	};
+	ASSERT_SIZE(cTurret, 0x6D0);
+}


### PR DESCRIPTION
- Added `cTurret`, `cCulturalTarget`, `tCultureTargetInfo`, `tDeferredEvent` classes.
- Improved fields in `cCity`, including `mBuildingsLayout`, `mDecorationsLayout`, `mTurretsLayout`.
- Added `cCity::ProcessBuildingUpdate()`.
- Improved `cCityWalls`.
- Added `cGameNounManager::GetPlayerCivilization()`.
- Fixed `cCreatureBase` virtual methods.