### PR TITLE
Added 7 new functions and more documentation to class cScenarioPlayMode

### DIFF
--- a/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
+++ b/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
@@ -791,6 +791,12 @@ namespace Simulator
 		DefineAddress(SetCurrentAct, SelectAddress(0xF1F260, 0xF1EE70));
 		DefineAddress(JumpToAct, SelectAddress(0xF1F7B0, 0xF1F3C0));
 		DefineAddress(SetState, SelectAddress(0xF1ADB0, 0xF1A9C0));
+		DefineAddress(UpdateGoals, SelectAddress(0xF1C780, 0xF1C390));
+		DefineAddress(Update, SelectAddress(0xF1FD50, 0xF1F960));
+		DefineAddress(CompleteAct, SelectAddress(0xF1F680, 0xF1F290));
+		DefineAddress(CheckGoalProgress, SelectAddress(0xF1F8D0, 0xF1F4E0));
+		DefineAddress(RemoveInvisibleClasses, SelectAddress(0xF1AFD0, 0xF1ABE0));
+		DefineAddress(ReadScenarioTuning, SelectAddress(0xF1E2F0, 0xF1DF00));
 	}
 
 	namespace Addresses(cPlanetRecord)

--- a/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
+++ b/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
@@ -790,6 +790,7 @@ namespace Simulator
 		DefineAddress(Initialize, SelectAddress(0xF1F450, 0xF1F060));
 		DefineAddress(SetCurrentAct, SelectAddress(0xF1F260, 0xF1EE70));
 		DefineAddress(JumpToAct, SelectAddress(0xF1F7B0, 0xF1F3C0));
+		DefineAddress(SetState, SelectAddress(0xF1ADB0, 0xF1A9C0));
 	}
 
 	namespace Addresses(cPlanetRecord)

--- a/Spore ModAPI/SourceCode/Simulator/Scenario.cpp
+++ b/Spore ModAPI/SourceCode/Simulator/Scenario.cpp
@@ -75,5 +75,11 @@ namespace Simulator
 	auto_METHOD_VOID(cScenarioPlayMode, JumpToAct, Args(int actIndex), Args(actIndex));
 	auto_METHOD_VOID_(cScenarioPlayMode, Initialize);
 	auto_METHOD_VOID(cScenarioPlayMode, SetState, Args(ScenarioPlayModeState state), Args(state));
+	auto_METHOD_(cScenarioPlayMode, bool, UpdateGoals);
+	auto_METHOD_VOID(cScenarioPlayMode, Update, Args(int deltaTime), Args(deltaTime));
+	auto_METHOD_VOID_(cScenarioPlayMode, CompleteAct);
+	auto_METHOD_VOID_(cScenarioPlayMode, CheckGoalProgress);
+	auto_STATIC_METHOD_VOID_(cScenarioPlayMode, RemoveInvisibleClasses);
+	auto_STATIC_METHOD_VOID_(cScenarioPlayMode, ReadScenarioTuning);
 }
 #endif

--- a/Spore ModAPI/SourceCode/Simulator/Scenario.cpp
+++ b/Spore ModAPI/SourceCode/Simulator/Scenario.cpp
@@ -74,5 +74,6 @@ namespace Simulator
 	auto_METHOD_VOID(cScenarioPlayMode, SetCurrentAct, Args(int index, bool arg), Args(index, arg));
 	auto_METHOD_VOID(cScenarioPlayMode, JumpToAct, Args(int actIndex), Args(actIndex));
 	auto_METHOD_VOID_(cScenarioPlayMode, Initialize);
+	auto_METHOD_VOID(cScenarioPlayMode, SetState, Args(ScenarioPlayModeState state), Args(state));
 }
 #endif

--- a/Spore ModAPI/Spore/Simulator/cScenarioPlayMode.h
+++ b/Spore ModAPI/Spore/Simulator/cScenarioPlayMode.h
@@ -59,6 +59,8 @@ namespace Simulator
 		void Initialize();
 		void SetCurrentAct(int actIndex, bool = false);
 		void JumpToAct(int actIndex);
+		void SetState(ScenarioPlayModeState state);
+
 
 	public:
 		/* 0Ch */	cScenarioPlaySummary mSummary;
@@ -113,5 +115,6 @@ namespace Simulator
 		DeclareAddress(Initialize);		// 0xF1F450, 0xF1F060
 		DeclareAddress(SetCurrentAct);  // 0xF1F260, 0xF1EE70
 		DeclareAddress(JumpToAct);		// 0xF1F7B0, 0xF1F3C0
+		DeclareAddress(SetState);		// 0xF1ADB0, 0xF1A9C0
 	}
 }

--- a/Spore ModAPI/Spore/Simulator/cScenarioPlayMode.h
+++ b/Spore ModAPI/Spore/Simulator/cScenarioPlayMode.h
@@ -56,10 +56,27 @@ namespace Simulator
 	public:
 		//TODO check sub_F1EFC0
 		
+		/// Called when starting the adventure in Play Mode.
 		void Initialize();
+		/// Sets the current act index of the active adventure.
 		void SetCurrentAct(int actIndex, bool = false);
+		/// Skips the adventure up to the given act index. Also works in reverse, i. e. going back to previous acts in the adventure. 
+		/// Using the same index as the current act will reset the adventure to the beginning of said act.
 		void JumpToAct(int actIndex);
+		/// Sets the active state of the adventure.
 		void SetState(ScenarioPlayModeState state);
+		/// Updates the current, active goals of the adventure.
+		bool UpdateGoals();
+		/// Update function of the adventure.
+		void Update(int deltaTime);
+		/// Completes the act, then moves the adventure into the next act. If in the last act, the adventure completes.
+		void CompleteAct();
+		/// Called by Update(). Checks if the current goals are clearable or not. 
+		void CheckGoalProgress();  
+
+		/// Removes objects that are supposed to be invisible during the current act.
+		static void RemoveInvisibleClasses();
+		static void ReadScenarioTuning();
 
 
 	public:
@@ -113,8 +130,15 @@ namespace Simulator
 	namespace Addresses(cScenarioPlayMode)
 	{
 		DeclareAddress(Initialize);		// 0xF1F450, 0xF1F060
-		DeclareAddress(SetCurrentAct);  // 0xF1F260, 0xF1EE70
+		DeclareAddress(SetCurrentAct);	// 0xF1F260, 0xF1EE70
 		DeclareAddress(JumpToAct);		// 0xF1F7B0, 0xF1F3C0
 		DeclareAddress(SetState);		// 0xF1ADB0, 0xF1A9C0
+		DeclareAddress(UpdateGoals);	// 0xF1C780, 0xF1C390
+		DeclareAddress(Update);			// 0xF1FD50, 0xF1F960
+		DeclareAddress(CompleteAct);	// 0xF1F680, 0xF1F290
+		DeclareAddress(CheckGoalProgress);	// 0xF1F8D0, 0xF1F4E0
+
+		DeclareAddress(RemoveInvisibleClasses); // 0xF1AFD0, 0xF1ABE0
+		DeclareAddress(ReadScenarioTuning); // 0xF1E2F0, 0xF1DF00
 	}
 }


### PR DESCRIPTION
* Added 7 new and known functions from Ghidra to ``cScenarioPlayMode``:
```c++
/// Sets the active state of the adventure.
void SetState(ScenarioPlayModeState state);

/// Updates the current, active goals of the adventure.
bool UpdateGoals();

/// Update function of the adventure.
void Update(int deltaTime);

/// Completes the act, then moves the adventure into the next act. If in the last act, the adventure completes.
void CompleteAct();

/// Called by Update(). Checks if the current goals are clearable or not. 
void CheckGoalProgress();  

/// Removes objects that are supposed to be invisible during the current act.
static void RemoveInvisibleClasses();

/// Unknown
static void ReadScenarioTuning();
```
* Added comments to other functions of ``cScenarioPlayMode``:
```c++
/// Called when starting the adventure in Play Mode.
void Initialize();

/// Sets the current act index of the active adventure.
void SetCurrentAct(int actIndex, bool = false);

/// Skips the adventure up to the given act index. Also works in reverse, i. e. going back to previous acts in the adventure. 
/// Using the same index as the current act will reset the adventure to the beginning of said act.
void JumpToAct(int actIndex);
```

Special thanks to Rosalie for documenting some of these functions earlier in Ghidra, and to ERROR for helping me figure out some of these.