### PR TITLE
Add a mutex to the logger so multiple threads can safely log messages

### DIFF
--- a/Spore ModAPI/SourceCode/DLL/Application.cpp
+++ b/Spore ModAPI/SourceCode/DLL/Application.cpp
@@ -64,6 +64,7 @@ namespace ModAPI
 	eastl::fixed_vector<InitFunction, MAX_MODS> disposeFunctions;
 	eastl::fixed_map<uint32_t, ISimulatorStrategyPtr, MAX_MODS> simulatorStrategies;
 	FileStreamPtr logFile{};
+	std::mutex logFileMutex;
 	__time64_t logFileStartTime;
 
 	uint32_t CRC_TABLE[256];
@@ -197,15 +198,19 @@ void CreateLogFile() {
 	log_file_name += u".txt";
 	log_path.append(log_file_name);
 
+	ModAPI::logFileMutex.lock();
 	ModAPI::logFile = new IO::FileStream(log_path.c_str());
 	ModAPI::logFile->Open(IO::AccessFlags::Write, IO::CD::CreateAlways);
+	ModAPI::logFileMutex.unlock();
 }
 
 void CloseLogFile() {
+	ModAPI::logFileMutex.lock();
 	if (ModAPI::logFile) {
 		ModAPI::logFile->Close();
 		ModAPI::logFile.reset();
 	}
+	ModAPI::logFileMutex.unlock();
 }
 
 int ModAPI::PreInit_detour::DETOUR(int arg_0, int arg_1)

--- a/Spore ModAPI/SourceCode/DLL/Application.h
+++ b/Spore ModAPI/SourceCode/DLL/Application.h
@@ -14,6 +14,7 @@
 #include <Spore\Cheats.h>
 #include <Spore\IO.h>
 #include <ctime>
+#include <mutex>
 
 virtual_detour(ShaderFragments_detour, Graphics::cMaterialManager, Graphics::IMaterialManager, bool(Resource::Database*)) {};
 
@@ -28,6 +29,7 @@ namespace ModAPI
 
 	extern FileStreamPtr logFile;
 	extern __time64_t logFileStartTime;
+	extern std::mutex logFileMutex;
 
 	long AttachDetour();
 	void DetachDetour();


### PR DESCRIPTION
Currently using ModAPI::Log from multiple threads results in broken logging, making it hard to use, adding a mutex prevents this