### PR TITLE
Add BuildCombinedDll target and build it with CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
           $count = git log --oneline | wc -l
           echo "Building version $count"
           msbuild "Spore ModAPI" -t:BuildDlls -p:BuildVer=$count -p:Config=Release
+          msbuild "Spore ModAPI" -t:BuildCombinedDll -p:BuildVer=$count -p:Config=Release
 
       - name: Upload compiled files
         uses: actions/upload-artifact@v3.1.3
@@ -34,6 +35,7 @@ jobs:
           path: |
             dll\Release\SporeModAPI.march2017.dll
             dll\Release\SporeModAPI.disk.dll
+            dll\Release\SporeModAPI.combined.dll
             dll\Release\SporeModAPI.lib
 
   deploy:
@@ -47,7 +49,7 @@ jobs:
           name: compiled-modapi-dlls
 
       - name: Create update bundle
-        run: zip SporeModAPIdlls.zip SporeModAPI.march2017.dll SporeModAPI.disk.dll SporeModAPI.lib
+        run: zip SporeModAPIdlls.zip SporeModAPI.march2017.dll SporeModAPI.disk.dll SporeModAPI.combined.dll SporeModAPI.lib
 
       # - name: Upload dlls bundle
       #   uses: actions/upload-artifact@v3.1.3

--- a/Spore ModAPI/Spore ModAPI.vcxproj
+++ b/Spore ModAPI/Spore ModAPI.vcxproj
@@ -1088,4 +1088,9 @@
     <Exec Command="msbuild.exe /p:Configuration=&quot;$(Config) DLL&quot; /p:Platform=Win32 /p:SDK_BUILD_VER=$(BuildVer) /p:EXECUTABLE_TYPE=0" />
     <Copy SourceFiles="../dll/$(Config)/SporeModAPI.dll" DestinationFiles="../dll/$(Config)/SporeModAPI.disk.dll" />
   </Target>
+  <Target Name="BuildCombinedDll">
+    <Message Text="Compiling $(Config) DLL, build $(BuildVer)..." />
+    <Exec Command="msbuild.exe /p:Configuration=&quot;$(Config) DLL&quot; /p:Platform=Win32 /p:SDK_BUILD_VER=$(BuildVer) /p:EXECUTABLE_TYPE=10" />
+    <Copy SourceFiles="../dll/$(Config)/SporeModAPI.dll" DestinationFiles="../dll/$(Config)/SporeModAPI.combined.dll" />
+  </Target>
 </Project>


### PR DESCRIPTION
This adds a combined dll target which builds the single dll which supports both the disk and march17 version.

I want to add this because I'm considering adding an update function to SporeModLoader.