### PR TITLE
Add asset-type functions & some other misc addresses

### DIFF
--- a/Spore ModAPI/SourceCode/DLL/AddressesEditors.cpp
+++ b/Spore ModAPI/SourceCode/DLL/AddressesEditors.cpp
@@ -80,6 +80,11 @@ namespace Editors
 		DefineAddress(PostEventToActors, SelectAddress(0x574000, 0x574110));
 
 		DefineAddress(HandleMessage, SelectAddress(0x591C80, 0x591FA0));
+
+
+		DefineAddress(GetEditorForAssetType, SelectAddress(0x00433010, 0x004333e0));
+		DefineAddress(GetNameForAssetType, SelectAddress(0x004badc0, 0x004bba50));
+		DefineAddress(GetTypeIDForAssetType, SelectAddress(0x004bb110, 0x004bbda0));
 	}
 
 	namespace Addresses(EditorCamera)

--- a/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
+++ b/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
@@ -200,10 +200,12 @@ namespace Simulator
 		DefineAddress(OnJumpLand, SelectAddress(0xC044D0, 0xC04CB0));
 		DefineAddress(OnStartSwimming, SelectAddress(0xC04610, 0xC04DF0));
 		DefineAddress(Update, SelectAddress(0xC0A590, 0xC0AE30));
+		DefineAddress(TakeDamage, SelectAddress(0xBFC500, 0xBFCF10));
 	}
 
 	namespace Addresses(cCreatureCitizen) {
 		DefineAddress(Update, SelectAddress(0xC24210, 0xC24A30));
+		DefineAddress(TakeDamage, SelectAddress(0xBFC500, 0xBFCF10));
 	}
 
 	namespace Addresses(cCreatureBase)
@@ -229,6 +231,12 @@ namespace Simulator
 		DefineAddress(OnJumpLand, SelectAddress(0xC14670, 0xC14E10));
 		DefineAddress(OnStartSwimming, SelectAddress(0xC147D0, 0xC14F70));
 		DefineAddress(Update, SelectAddress(0xC20C50, 0xC21530));
+		DefineAddress(TakeDamage, SelectAddress(0xBFC500, 0xBFCF10));
+	}
+
+	namespace Addresses(cCombatant)
+	{
+		DefineAddress(TakeDamage, SelectAddress(0xBFC500, 0xBFCF10));
 	}
 
 	namespace Addresses(cCropCirclesToolStrategy)

--- a/Spore ModAPI/SourceCode/Editors/Editor.cpp
+++ b/Spore ModAPI/SourceCode/Editors/Editor.cpp
@@ -192,5 +192,11 @@ namespace Editors
 
 
 	auto_METHOD_VOID(EditorRigblock, SetShadedDisplay, Args(bool isShaded), Args(isShaded));
+
+	auto_STATIC_METHOD(cEditor, uint32_t, GetEditorForAssetType, Args(uint32_t assetTypeID), Args(assetTypeID));
+
+	auto_STATIC_METHOD(cEditor, uint32_t, GetTypeIDForAssetType, Args(uint32_t assetTypeID), Args(assetTypeID));
+
+	auto_STATIC_METHOD(cEditor, const char16_t*, GetNameForAssetType, Args(uint32_t assetTypeID), Args(assetTypeID));
 }
 #endif

--- a/Spore ModAPI/Spore/Editors/Editor.h
+++ b/Spore ModAPI/Spore/Editors/Editor.h
@@ -207,6 +207,12 @@ namespace Editors
 
 		void PostEventToActors(uint32_t eventID, int = -1, float = 1.0f, float = 0.0f);
 
+		static uint32_t GetEditorForAssetType(uint32_t assetTypeID);
+
+		static const char16_t* GetNameForAssetType(uint32_t assetTypeID);
+
+		static uint32_t GetTypeIDForAssetType(uint32_t assetTypeID);
+
 	public:
 
 		int vftable_1C;
@@ -628,6 +634,11 @@ namespace Editors
 		DeclareAddress(PostEventToActors);  // 0x574000 0x574110
 
 		DeclareAddress(HandleMessage);  // 0x591C80 0x591FA0
+
+
+		DeclareAddress(GetEditorForAssetType);
+		DeclareAddress(GetNameForAssetType);
+		DeclareAddress(GetTypeIDForAssetType);
 	}
 
 #ifdef SDK_TO_GHIDRA

--- a/Spore ModAPI/Spore/Simulator/cCombatant.h
+++ b/Spore ModAPI/Spore/Simulator/cCombatant.h
@@ -151,4 +151,8 @@ namespace Simulator
 	};
 	ASSERT_SIZE(cCombatant, 0xC8);
 
+	namespace Addresses(cCombatant){
+		DeclareAddress(TakeDamage);
+	}
+
 }

--- a/Spore ModAPI/Spore/Simulator/cCreatureAnimal.h
+++ b/Spore ModAPI/Spore/Simulator/cCreatureAnimal.h
@@ -92,5 +92,6 @@ namespace Simulator
 		DeclareAddress(OnJumpLand);  // 0xC044D0 0xC04CB0
 		DeclareAddress(OnStartSwimming);  // 0xC04610 0xC04DF0
 		DeclareAddress(Update);  // 0xC0A590 0xC0AE30
+		DeclareAddress(TakeDamage);
 	}
 }

--- a/Spore ModAPI/Spore/Simulator/cCreatureBase.h
+++ b/Spore ModAPI/Spore/Simulator/cCreatureBase.h
@@ -415,5 +415,6 @@ namespace Simulator
 		DeclareAddress(OnJumpLand);  // 0xC14670 0xC14E10
 		DeclareAddress(OnStartSwimming);  // 0xC147D0 0xC14F70
 		DeclareAddress(Update);  // 0xC20C50 0xC21530
+		DeclareAddress(TakeDamage);
 	}
 }

--- a/Spore ModAPI/Spore/Simulator/cCreatureCitizen.h
+++ b/Spore ModAPI/Spore/Simulator/cCreatureCitizen.h
@@ -44,5 +44,6 @@ namespace Simulator
 
 	namespace Addresses(cCreatureCitizen) {
 		DeclareAddress(Update);  // 0xC24210 0xC24A30
+		DeclareAddress(TakeDamage);
 	}
 }


### PR DESCRIPTION
This pull request adds the TakeDamage addresses to cCombatant, cCreatureBase, cCreatureAnimal and cCreatureCitizen.
It also adds asset type functions - GetEditorForAssetType, GetNameForAssetType and GetTypeIDForAssetType.
(The latter also dictates how the type behaves in-game, as the TypeID (.crt, .cll, .vcl, .bld, etc.) dictates how the game treats it.