### PR TITLE
Add support for oct2024 in combined DLL

### DIFF
--- a/Spore ModAPI/SourceCode/DLL/DllModAPI.cpp
+++ b/Spore ModAPI/SourceCode/DLL/DllModAPI.cpp
@@ -107,7 +107,7 @@ namespace ModAPI
 			cachedGameType = GameType::Disk;
 			hasFoundGameType = true;
 		}
-		else if (size.QuadPart == 24885248)
+		else if (size.QuadPart == 24885248 || size.QuadPart == 24895536)
 		{ // steam patched version
 			cachedGameType = GameType::March2017;
 			hasFoundGameType = true;


### PR DESCRIPTION
Addresses didn't shift in the oct2024 version so this works fine.