### PR TITLE
Fix enumtype for Security Drones

### DIFF
--- a/Spore ModAPI/Spore/Simulator/SimulatorEnums.h
+++ b/Spore ModAPI/Spore/Simulator/SimulatorEnums.h
@@ -686,10 +686,10 @@ namespace Simulator
 		Unk5 = 5,
 		Defender = 6,
 		Unk7 = 7,
-		Unk8 = 8,
+		AmbushPirate = 8,
 		Unk9 = 9,
 		Unk10 = 10,
-		Unk11 = 10,
+		SecurityDrone = 11,
 	};
 
 	enum TribeToolType


### PR DESCRIPTION
There is a typo where the Unk11 enum type for `UfoTypes` is set to 10. Also properly documented Unk8 and Unk11 to their respective UFO types being AmbushPirate and SecurityDrone where they appear in the base game.