### PR TITLE
ci: improve workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,5 @@
 name: Deploy ModAPI Dlls & Update Documentation
-on:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 jobs:
   compile:
     name: Compile ModAPI core DLLS
@@ -42,6 +39,7 @@ jobs:
     name: Deploy ModAPI DLLs update
     needs: compile
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Download compiled files
         uses: actions/download-artifact@v4
@@ -50,12 +48,6 @@ jobs:
 
       - name: Create update bundle
         run: zip SporeModAPIdlls.zip SporeModAPI.march2017.dll SporeModAPI.disk.dll SporeModAPI.combined.dll SporeModAPI.lib
-
-      # - name: Upload dlls bundle
-      #   uses: actions/upload-artifact@v3.1.3
-      #   with:
-      #     name: compiled-modapi-dlls-bundle
-      #     path: SporeModAPIdlls.zip
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -89,6 +81,7 @@ jobs:
   documentation:
     name: Generate documentation
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Install Doxygen
         uses: ssciwr/doxygen-install@v1.2.0
@@ -126,12 +119,16 @@ jobs:
           git init
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git remote add origin https://github.com/emd4600/Spore-ModAPI.git
+          git remote add origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git
           git fetch
           git symbolic-ref HEAD refs/remotes/origin/gh-pages
           git reset
-          git add .
-          git commit -m "Documentation update $count"
+          # only commit when uncomitted changes are available
+          if [[ "$(git diff --name-only refs/remotes/origin/gh-pages | wc -l)" != "0" ]]
+          then
+            git add .
+            git commit -m "Documentation update $count"
+          fi
 
       - name: Upload changes to GitHub
         uses: ad-m/github-push-action@master


### PR DESCRIPTION
This allows Github Actions to run with PRs and fixes the CI failure when no documentation changes are made.