### PR TITLE
Add console function names to cheat manager

### DIFF
--- a/Spore ModAPI/SourceCode/App/CheatManager.cpp
+++ b/Spore ModAPI/SourceCode/App/CheatManager.cpp
@@ -36,9 +36,9 @@ namespace App
 	auto_METHOD_VIRTUAL_VOID(cCheatManager, cCheatManager, func30h, Args(Object* arg_0), Args(arg_0));
 	auto_METHOD_VIRTUAL_VOID(cCheatManager, cCheatManager, func34h, Args(Object* arg_0), Args(arg_0));
 	auto_METHOD_VIRTUAL_(cCheatManager, cCheatManager, ArgScript::FormatParser*, GetArgScript);
-	auto_METHOD_VIRTUAL_VOID(cCheatManager, cCheatManager, func3Ch, Args(int arg_0), Args(arg_0));
-	auto_METHOD_VIRTUAL_VOID(cCheatManager, cCheatManager, func40h, Args(int arg_0), Args(arg_0));
-	auto_METHOD_VIRTUAL_VOID(cCheatManager, cCheatManager, func44h, Args(int arg_0), Args(arg_0));
+	auto_METHOD_VIRTUAL_VOID(cCheatManager, cCheatManager, ActivateConsole, Args(int arg_0), Args(arg_0));
+	auto_METHOD_VIRTUAL_VOID(cCheatManager, cCheatManager, DeactivateConsole, Args(int arg_0), Args(arg_0));
+	auto_METHOD_VIRTUAL_VOID(cCheatManager, cCheatManager, ToggleConsole, Args(int arg_0), Args(arg_0));
 	auto_METHOD_VIRTUAL_(cCheatManager, cCheatManager, bool, func48h);
 	auto_METHOD_VIRTUAL_VOID(cCheatManager, cCheatManager, func4Ch, Args(bool arg_0), Args(arg_0));
 

--- a/Spore ModAPI/SourceCode/DLL/AddressesApp.cpp
+++ b/Spore ModAPI/SourceCode/DLL/AddressesApp.cpp
@@ -84,9 +84,9 @@ namespace App
 		DefineAddress(func30h, SelectAddress(0x67F7E0, 0x67F500));
 		DefineAddress(func34h, SelectAddress(0x67F860, 0x67F580));
 		DefineAddress(GetArgScript, SelectAddress(0x113BA60, 0x113AE80));
-		DefineAddress(func3Ch, SelectAddress(0x67E880, 0x67E6B0));
-		DefineAddress(func40h, SelectAddress(0x67E8C0, 0x67E6F0));
-		DefineAddress(func44h, SelectAddress(0x67E900, 0x67E730));
+		DefineAddress(ActivateConsole, SelectAddress(0x67E880, 0x67E6B0));
+		DefineAddress(DeactivateConsole, SelectAddress(0x67E8C0, 0x67E6F0));
+		DefineAddress(ToggleConsole, SelectAddress(0x67E900, 0x67E730));
 		DefineAddress(func48h, SelectAddress(0xABFB10, 0xABF790));
 		DefineAddress(func4Ch, SelectAddress(0x67E200, 0x67E0A0));
 	}

--- a/Spore ModAPI/Spore/App/ICheatManager.h
+++ b/Spore ModAPI/Spore/App/ICheatManager.h
@@ -107,9 +107,23 @@ namespace App
 		///
 		/* 38h */	virtual ArgScript::FormatParser* GetArgScript() = 0;
 
-		/* 3Ch */	virtual void func3Ch(int) = 0;
-		/* 40h */	virtual void func40h(int) = 0;
-		/* 44h */	virtual void func44h(int) = 0;
+		///
+		/// Opens the cheat console.
+		///
+		/* 3Ch */	virtual void ActivateConsole(int = 1) = 0;
+
+		///
+		/// Closes the cheat console.
+		/// Called when the game automatically closes the console, such as when opening certain UIs.
+		///
+		/* 40h */	virtual void DeactivateConsole(int = 1) = 0;
+
+		///
+		/// Toggles whether the cheat console is open.
+		/// Called when the user presses Ctrl+Shift+C.
+		///
+		/* 44h */	virtual void ToggleConsole(int = 1) = 0;
+
 		/* 48h */	virtual bool func48h() = 0;
 		/* 4Ch */	virtual void func4Ch(bool) = 0;
 

--- a/Spore ModAPI/Spore/App/cCheatManager.h
+++ b/Spore ModAPI/Spore/App/cCheatManager.h
@@ -59,9 +59,9 @@ namespace App
 		virtual void func30h(Object*) override;
 		virtual void func34h(Object*) override;
 		virtual ArgScript::FormatParser* GetArgScript() override;
-		virtual void func3Ch(int) override;
-		virtual void func40h(int) override;
-		virtual void func44h(int) override;
+		virtual void ActivateConsole(int) override;
+		virtual void DeactivateConsole(int) override;
+		virtual void ToggleConsole(int) override;
 		virtual bool func48h() override;
 		virtual void func4Ch(bool) override;
 
@@ -93,9 +93,9 @@ namespace App
 		DeclareAddress(func30h);
 		DeclareAddress(func34h);
 		DeclareAddress(GetArgScript);
-		DeclareAddress(func3Ch);
-		DeclareAddress(func40h);
-		DeclareAddress(func44h);
+		DeclareAddress(ActivateConsole);
+		DeclareAddress(DeactivateConsole);
+		DeclareAddress(ToggleConsole);
 		DeclareAddress(func48h);
 		DeclareAddress(func4Ch);
 	}


### PR DESCRIPTION
Added names for three functions related to the cheat console:
- ActivateConsole: opens the cheat console
- DeactivateConsole: closes the cheat console, called automatically by game on certain screens, can be detoured to prevent auto-closing
- ToggleConsole: does the same thing as Ctrl+Shift+C

Parameters are set to always be 1; it does nothing if it's 0