### PR TITLE
add DefineAddressAlias and declare old aliases for cheat manager functions

### DIFF
--- a/Spore ModAPI/SourceCode/DLL/AddressesApp.cpp
+++ b/Spore ModAPI/SourceCode/DLL/AddressesApp.cpp
@@ -85,8 +85,11 @@ namespace App
 		DefineAddress(func34h, SelectAddress(0x67F860, 0x67F580));
 		DefineAddress(GetArgScript, SelectAddress(0x113BA60, 0x113AE80));
 		DefineAddress(ActivateConsole, SelectAddress(0x67E880, 0x67E6B0));
+		DefineAddressAlias(func3Ch, ActivateConsole);
 		DefineAddress(DeactivateConsole, SelectAddress(0x67E8C0, 0x67E6F0));
+		DefineAddressAlias(func40h, DeactivateConsole);
 		DefineAddress(ToggleConsole, SelectAddress(0x67E900, 0x67E730));
+		DefineAddressAlias(func44h, ToggleConsole);
 		DefineAddress(func48h, SelectAddress(0xABFB10, 0xABF790));
 		DefineAddress(func4Ch, SelectAddress(0x67E200, 0x67E0A0));
 	}

--- a/Spore ModAPI/Spore/CppRevEngBase.h
+++ b/Spore ModAPI/Spore/CppRevEngBase.h
@@ -118,6 +118,11 @@ RedirectMethod_noargs_const(Window, GetParent, Window*);
 #define DeclareAddress(name) extern MODAPI const uintptr_t name
 #endif
 #define DefineAddress(name, value) const uintptr_t name = value - 0x400000
+#ifdef SDK_TO_GHIDRA
+#define DefineAddressAlias(alias, name)
+#else
+#define DefineAddressAlias(alias, name) const uintptr_t alias = name
+#endif
 
 // Returns the address stored with a DeclareAddress() in the given addresses namespace.
 #define GetAddress(namespaceName, name) (Addresses(namespaceName)::name + baseAddress)


### PR DESCRIPTION
This should fix mods using old function names