### PR TITLE
Add more serialization-related classes

### DIFF
--- a/Spore ModAPI/SourceCode/App/App.cpp
+++ b/Spore ModAPI/SourceCode/App/App.cpp
@@ -43,6 +43,10 @@ namespace App
 		Args(const eastl::string16& path, eastl::hash_set<eastl::string16>& dstSkippedPaths, int& dstCount),
 		Args(path, dstSkippedPaths, dstCount));
 
+	auto_METHOD(PngEncoder, bool, ReadImageData,
+		Args(IO::IStream* inputStream),
+		Args(inputStream));
+
 	auto_METHOD(PngEncoder, bool, WriteImageToStream,
 		Args(IO::IStream* stream, App::PngEncoder::Format format),
 		Args(stream, format));

--- a/Spore ModAPI/SourceCode/DLL/AddressesApp.cpp
+++ b/Spore ModAPI/SourceCode/DLL/AddressesApp.cpp
@@ -416,6 +416,7 @@ namespace App
 
 	namespace Addresses(PngEncoder)
 	{
+		DefineAddress(ReadImageData, SelectAddress(0x682470, 0x68eb40));
 		DefineAddress(WriteImageToStream, SelectAddress(0x68E660, 0x68e190));
 		DefineAddressAlias(EncodePNG, WriteImageToStream);
 	}

--- a/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
+++ b/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
@@ -723,6 +723,56 @@ namespace Simulator
 		DefineAddress(GetAllocator, SelectAddress(0x690180, 0x69de70));
 	}
 
+	namespace Addresses(SerializerReadStream)
+	{
+		DefineAddress(Open, SelectAddress(0x6903b0, 0x69e090));
+		DefineAddress(Close, SelectAddress(0x68f860, 0x69d480));
+		DefineAddress(IsOpen, SelectAddress(0x68f8b0, 0x69d4d0));
+		DefineAddress(IsGood, SelectAddress(0x5a2c00, 0x950190));
+		DefineAddress(GetRecord, SelectAddress(0x69f450, 0xfc7910));
+		DefineAddress(GetDatabase, SelectAddress(0xf5c360, 0x7f55c0));
+		DefineAddress(ReadObjectPointer, SelectAddress(0x690450, 0x69e170));
+		DefineAddress(ReadPointer, SelectAddress(0x68f8d0, 0x69d4f0));
+		DefineAddress(ReadProperty, SelectAddress(0x68f920, 0x69d540));
+		DefineAddress(ReadRawData, SelectAddress(0x68fbb0, 0x69d830));
+		DefineAddress(ReadPropertyByID, SelectAddress(0x68f5e0, 0x69d1d0));
+		DefineAddress(GetSerializationVersion, SelectAddress(0x95a4f0, 0x93b630));
+		DefineAddress(SetSerializationVersion, SelectAddress(0x1054390, 0xfcc100));
+
+		DefineAddress(Skip, SelectAddress(0x68f620, 0x69d210));
+	}
+
+	namespace Addresses(SerializerWriteStream)
+	{
+		DefineAddress(Open, SelectAddress(0x690540, 0x69e260));
+		DefineAddress(Close, SelectAddress(0x68fc30, 0x69d8e0));
+		DefineAddress(IsOpen, SelectAddress(0x68fc80, 0x69d930));
+		DefineAddress(IsGood, SelectAddress(0x68f690, 0xab2ff0));
+		DefineAddress(GetRecord, SelectAddress(0x959a00, 0xfcc1d0));
+		DefineAddress(GetDatabase, SelectAddress(0x95a4f0, 0x93b630));
+		DefineAddress(WriteObjectPointer, SelectAddress(0x68fca0, 0x69d950));
+		DefineAddress(WritePointer, SelectAddress(0x68fcd0, 0x69d980));
+		DefineAddress(WriteProperty, SelectAddress(0x68fd20, 0x69d9d0));
+		DefineAddress(WriteRawData, SelectAddress(0x68ffb0, 0x69dc60));
+		DefineAddress(WritePropertyWithID, SelectAddress(0x68f6a0, 0x69d280));
+	}
+
+	namespace Addresses(SerializerReadStreamPrivate)
+	{
+		DefineAddress(IsOpen, SelectAddress(0x685e30, 0x692e60));
+		DefineAddress(SetSerializationVersion, SelectAddress(0x685e10, 0x692e80));
+		DefineAddress(GetSerializationVersion, SelectAddress(0x685e20, 0x692e90));
+
+		DefineAddress(openStream, SelectAddress(0x686770, 0x6938d0));
+	}
+
+	namespace Addresses(SerializerWriteStreamPrivate)
+	{
+		DefineAddress(IsOpen, SelectAddress(0x685e30, 0x692e60));
+
+		DefineAddress(openStream, SelectAddress(0x686890, 0x693a70));
+	}
+
 	namespace Addresses(cGameData)
 	{
 		DefineAddress(Write, SelectAddress(0xB18430, 0xB184D0));

--- a/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
+++ b/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
@@ -672,6 +672,57 @@ namespace Simulator
 		DefineAddress(AttributesToXml, SelectAddress(0x695D40, 0x695B20));
 	}
 
+	namespace Addresses(COMSerializer)
+	{
+		DefineAddress(Open, SelectAddress(0x6902d0, 0x69dfc0));
+		DefineAddress(Close, SelectAddress(0x691910, 0x69f940));
+		DefineAddress(LoadClassObjects, SelectAddress(0x691240, 0x69f1d0));
+		DefineAddress(SaveClassObjects, SelectAddress(0x691af0, 0x69fb90));
+		DefineAddress(Write, SelectAddress(0x692440, 0x6a05f0));
+		DefineAddress(Read, SelectAddress(0x6924f0, 0x6a06a0));
+
+		DefineAddress(GetCRC, SelectAddress(0x690d40, 0x69ec20));
+		DefineAddress(reset, SelectAddress(0x6911d0, 0x69f160));
+		DefineAddress(onSetSPSerializable, SelectAddress(0x691ff0, 0x6a0110));
+		DefineAddress(onGetSPSerializable, SelectAddress(0x690bb0, 0x69e9e0));
+		DefineAddress(loadSingleObject, SelectAddress(0x6921e0, 0x6a0360));
+	}
+
+	namespace Addresses(SerializerDatabase)
+	{
+		DefineAddress(AsDatabase, SelectAddress(0x8fac50, 0x7f3190));
+		DefineAddress(GetCOMSerializer, SelectAddress(0x5a6210, 0x985d70));
+		DefineAddress(OpenReadStream, SelectAddress(0x690640, 0x69e3a0));
+		DefineAddress(CloseReadStream, SelectAddress(0x68f6e0, 0x69d2c0));
+		DefineAddress(LoadClassObjects, SelectAddress(0x690190, 0x69de80));
+		DefineAddress(OpenWriteStream, SelectAddress(0x6906d0, 0x69e470));
+		DefineAddress(CloseWriteStream, SelectAddress(0x68f6e0, 0x69d2c0));
+		DefineAddress(SaveClassObjects, SelectAddress(0x6901b0, 0x69dea0));
+		DefineAddress(HasKey, SelectAddress(0x6907d0, 0x69e5d0));
+		DefineAddress(GetPercentageCompletion, SelectAddress(0x109ffe0, 0xc06490));
+		DefineAddress(SetPercentageCompletion, SelectAddress(0x68f710, 0x69d2f0));
+		DefineAddress(OpenAsSerializer, SelectAddress(0x690230, 0x69df20));
+
+		DefineAddress(Initialize, SelectAddress(0x6901d0, 0x69dec0));
+		DefineAddress(Dispose, SelectAddress(0x6901e0, 0x69ded0));
+		DefineAddress(GetDatabaseType, SelectAddress(0x6900a0, 0x69dd90));
+		DefineAddress(GetRefCount, SelectAddress(0x68f800, 0x69d3f0));
+		DefineAddress(Lock, SelectAddress(0x6900b0, 0x69dda0));
+		DefineAddress(Open, SelectAddress(0x6900c0, 0x69ddb0));
+		DefineAddress(Close, SelectAddress(0x6902a0, 0x69df90));
+		DefineAddress(GetAccessFlags, SelectAddress(0x6900d0, 0x69ddc0));
+		DefineAddress(Flush, SelectAddress(0x6900f0, 0x69dde0));
+		DefineAddress(GetLocation, SelectAddress(0x690100, 0x69ddf0));
+		DefineAddress(SetLocation, SelectAddress(0x690110, 0x69de00));
+		DefineAddress(GetKeyList, SelectAddress(0x690120, 0x69de10));
+		DefineAddress(OpenRecord, SelectAddress(0x690130, 0x69de20));
+		DefineAddress(GetOpenCount, SelectAddress(0x690140, 0x69de30));
+		DefineAddress(CloseRecord, SelectAddress(0x690150, 0x69de40));
+		DefineAddress(DeleteRecord, SelectAddress(0x690160, 0x69de50));
+		DefineAddress(Attach, SelectAddress(0x690170, 0x69de60));
+		DefineAddress(GetAllocator, SelectAddress(0x690180, 0x69de70));
+	}
+
 	namespace Addresses(cGameData)
 	{
 		DefineAddress(Write, SelectAddress(0xB18430, 0xB184D0));

--- a/Spore ModAPI/SourceCode/IO/IODefinitions.cpp
+++ b/Spore ModAPI/SourceCode/IO/IODefinitions.cpp
@@ -220,7 +220,7 @@ namespace Resource
 	auto_METHOD_VIRTUAL_const_(DatabasePackedFile, DatabasePackedFile, uint32_t, GetDatabaseType);
 	auto_METHOD_VIRTUAL_const_(DatabasePackedFile, DatabasePackedFile, int, GetRefCount);
 	auto_METHOD_VIRTUAL_VOID(DatabasePackedFile, DatabasePackedFile, Lock, Args(bool bLock), Args(bLock));
-	auto_METHOD_VIRTUAL(DatabasePackedFile, DatabasePackedFile, bool, Open, Args(IO::AccessFlags nDesiredAccess, IO::CD nCreateDisposition, bool arg_8), Args(nDesiredAccess, nCreateDisposition, arg_8));
+	auto_METHOD_VIRTUAL(DatabasePackedFile, DatabasePackedFile, bool, Open, Args(IO::AccessFlags nDesiredAccess, IO::CD nCreateDisposition, bool bAutoOpen), Args(nDesiredAccess, nCreateDisposition, bAutoOpen));
 	auto_METHOD_VIRTUAL_(DatabasePackedFile, DatabasePackedFile, bool, Close);
 	auto_METHOD_VIRTUAL_const_(DatabasePackedFile, DatabasePackedFile, IO::AccessFlags, GetAccessFlags);
 	auto_METHOD_VIRTUAL_(DatabasePackedFile, DatabasePackedFile, bool, Flush);
@@ -540,7 +540,7 @@ namespace Resource
 	//auto_METHOD_VIRTUAL_const_(DatabaseDirectoryFiles, DatabaseDirectoryFiles, uint32_t, GetDatabaseType);
 	auto_METHOD_VIRTUAL_const_(DatabaseDirectoryFiles, DatabaseDirectoryFiles, int, GetRefCount);
 	auto_METHOD_VIRTUAL_VOID(DatabaseDirectoryFiles, DatabaseDirectoryFiles, Lock, Args(bool bLock), Args(bLock));
-	auto_METHOD_VIRTUAL(DatabaseDirectoryFiles, DatabaseDirectoryFiles, bool, Open, Args(IO::AccessFlags nDesiredAccess, IO::CD nCreateDisposition, bool arg_8), Args(nDesiredAccess, nCreateDisposition, arg_8));
+	auto_METHOD_VIRTUAL(DatabaseDirectoryFiles, DatabaseDirectoryFiles, bool, Open, Args(IO::AccessFlags nDesiredAccess, IO::CD nCreateDisposition, bool bAutoOpen), Args(nDesiredAccess, nCreateDisposition, bAutoOpen));
 	auto_METHOD_VIRTUAL_(DatabaseDirectoryFiles, DatabaseDirectoryFiles, bool, Close);
 	//auto_METHOD_VIRTUAL_const_(DatabaseDirectoryFiles, DatabaseDirectoryFiles, int, GetAccessFlags);
 	auto_METHOD_VIRTUAL_(DatabaseDirectoryFiles, DatabaseDirectoryFiles, bool, Flush);

--- a/Spore ModAPI/SourceCode/IO/IniFile.cpp
+++ b/Spore ModAPI/SourceCode/IO/IniFile.cpp
@@ -33,6 +33,8 @@ namespace IO
 		mPath[0] = L'\0';
 	}
 
+	IniFile::~IniFile() = default;
+
 	auto_METHOD_VIRTUAL_const(IniFile, IniFile, int, GetOption, Args(Options option), Args(option));
 	auto_METHOD_VIRTUAL_VOID(IniFile, IniFile, SetOption, Args(Options option, int value), Args(option, value));
 	auto_METHOD_VIRTUAL_const_(IniFile, IniFile, wchar_t const*, GetPath);

--- a/Spore ModAPI/SourceCode/Simulator/Serialization.cpp
+++ b/Spore ModAPI/SourceCode/Simulator/Serialization.cpp
@@ -7,7 +7,7 @@ namespace Simulator
 		, pAttributes(_attributes)
 		, id(classID)
 		, count(0)
-		, field_A04(0)
+		, countSerialized(0)
 	{
 		Attribute* ptr = _attributes;
 		while (ptr->readFunction && ptr->writeFunction && count < 128) {
@@ -44,5 +44,165 @@ namespace Simulator
 	{
 
 	}
+
+#ifndef MODAPI_DLL_EXPORT
+
+	ICOMSerializer::~ICOMSerializer() = default;
+
+	COMSerializer::COMSerializer(ISerializerDatabase* pDatabase)
+		: mbBusyWritingClassObjects(false)
+		, mClassIDMapForWriting()
+		, mClassIDMap()
+		, mTotalSerializableCount(0)
+		, mbClassObjectsLoaded(false)
+		, mbClassObjectsSaved(false)
+		, mpDatabase(nullptr)
+		, mCRCDataBuffer()
+	{
+		reset();
+		mpDatabase = pDatabase;
+	}
+
+	COMSerializer::~COMSerializer() = default;
+
+	int COMSerializer::AddRef()
+	{
+		return DefaultRefCounted::AddRef();
+	}
+
+	int COMSerializer::Release()
+	{
+		return DefaultRefCounted::Release();
+	}
+
+	void* COMSerializer::Cast(uint32_t type) const
+	{
+		CLASS_CAST(ICOMSerializer);
+		return nullptr;
+	}
+
+	auto_METHOD_VIRTUAL(COMSerializer, ICOMSerializer, bool, Open,
+		Args(ISerializerDatabase* pDatabase),
+		Args(pDatabase));
+	auto_METHOD_VIRTUAL_(COMSerializer, ICOMSerializer, bool, Close);
+	auto_METHOD_VIRTUAL(COMSerializer, ICOMSerializer, bool, LoadClassObjects,
+		Args(uint32_t clientVersion),
+		Args(clientVersion));
+	auto_METHOD_VIRTUAL_(COMSerializer, ICOMSerializer, bool, SaveClassObjects);
+	auto_METHOD_VIRTUAL(COMSerializer, ICOMSerializer, bool, Write,
+		Args(ISerializerWriteStream& oSPStream, const ISimulatorSerializable* pSerializable),
+		Args(oSPStream, pSerializable));
+	auto_METHOD_VIRTUAL(COMSerializer, ICOMSerializer, bool, Read,
+		Args(ISerializerReadStream& iSPStream, const ISimulatorSerializable** ppSerializable, bool bLoadImmediately),
+		Args(iSPStream, ppSerializable, bLoadImmediately));
+
+	auto_METHOD(COMSerializer, bool, GetCRC,
+		Args(Resource::IRecord* pRecord, uint32_t nCRCDataLength, uint32_t& nCRC),
+		Args(pRecord, nCRCDataLength, nCRC));
+	auto_METHOD_VOID_(COMSerializer, reset);
+	auto_METHOD(COMSerializer, bool, onSetSPSerializable,
+		Args(const ISimulatorSerializable* pSerializable, uint32_t instanceID, uint32_t classID),
+		Args(pSerializable, instanceID, classID));
+	auto_METHOD(COMSerializer, bool, onGetSPSerializable,
+		Args(ISimulatorSerializable** ppSerializable, uint32_t instanceID, uint32_t classID),
+		Args(ppSerializable, instanceID, classID));
+	auto_METHOD(COMSerializer, bool, loadSingleObject,
+		Args(ISimulatorSerializable* pSerializable, uint32_t instanceID, uint32_t classID),
+		Args(pSerializable, instanceID, classID));
+
+	SerializerDatabase::SerializerDatabase(Database* pDatabase)
+		: mpDatabase(pDatabase)
+		, mpCOMSerializer(new COMSerializer(this))
+		, mfPercentageCompletion0To100(0.0f)
+	{
+
+	}
+
+	SerializerDatabase::~SerializerDatabase() = default;
+
+	int SerializerDatabase::AddRef()
+	{
+		return Database::AddRef();
+	}
+
+	int SerializerDatabase::Release()
+	{
+		return Database::Release();
+	}
+
+	void* SerializerDatabase::Cast(uint32_t type) const
+	{
+		CLASS_CAST(ISerializerDatabase);
+		return nullptr;
+	}
+
+	auto_METHOD_VIRTUAL_(SerializerDatabase, ISerializerDatabase, Resource::Database*, AsDatabase);
+	auto_METHOD_VIRTUAL_(SerializerDatabase, ISerializerDatabase, ICOMSerializer*, GetCOMSerializer);
+	auto_METHOD_VIRTUAL(SerializerDatabase, ISerializerDatabase, bool, OpenReadStream,
+		Args(const ResourceKey& key, ISerializerReadStream** ppStream),
+		Args(key, ppStream));
+	auto_METHOD_VIRTUAL(SerializerDatabase, ISerializerDatabase, bool, CloseReadStream,
+		Args(ISerializerReadStream* pStream),
+		Args(pStream));
+	auto_METHOD_VIRTUAL(SerializerDatabase, ISerializerDatabase, bool, LoadClassObjects,
+		Args(uint32_t version),
+		Args(version));
+	auto_METHOD_VIRTUAL(SerializerDatabase, ISerializerDatabase, bool, OpenWriteStream,
+		Args(const ResourceKey& key, ISerializerWriteStream** ppStream, bool bTruncate),
+		Args(key, ppStream, bTruncate));
+	auto_METHOD_VIRTUAL(SerializerDatabase, ISerializerDatabase, bool, CloseWriteStream,
+		Args(ISerializerWriteStream* pStream),
+		Args(pStream));
+	auto_METHOD_VIRTUAL_(SerializerDatabase, ISerializerDatabase, bool, SaveClassObjects);
+	auto_METHOD_VIRTUAL_const(SerializerDatabase, ISerializerDatabase, bool, HasKey,
+		Args(const ResourceKey& key),
+		Args(key));
+	auto_METHOD_VIRTUAL_const_(SerializerDatabase, ISerializerDatabase, float, GetPercentageCompletion);
+	auto_METHOD_VIRTUAL_VOID(SerializerDatabase, ISerializerDatabase, SetPercentageCompletion,
+		Args(float fPercentageCompletion0To100),
+		Args(fPercentageCompletion0To100));
+
+	auto_METHOD_VIRTUAL_(SerializerDatabase, Resource::Database, bool, Initialize);
+	auto_METHOD_VIRTUAL_(SerializerDatabase, Resource::Database, bool, Dispose);
+	auto_METHOD_VIRTUAL_const_(SerializerDatabase, Resource::Database, uint32_t, GetDatabaseType);
+	auto_METHOD_VIRTUAL_const_(SerializerDatabase, Resource::Database, int, GetRefCount);
+	auto_METHOD_VIRTUAL_VOID(SerializerDatabase, Resource::Database, Lock,
+		Args(bool lock),
+		Args(lock));
+	auto_METHOD_VIRTUAL(SerializerDatabase, Resource::Database, bool, Open,
+		Args(IO::AccessFlags desiredAccess, IO::CD createDisposition, bool bAutoOpen),
+		Args(desiredAccess, createDisposition, bAutoOpen));
+	auto_METHOD_VIRTUAL_(SerializerDatabase, Resource::Database, bool, Close);
+	auto_METHOD_VIRTUAL_const_(SerializerDatabase, Resource::Database, IO::AccessFlags, GetAccessFlags);
+	auto_METHOD_VIRTUAL_(SerializerDatabase, Resource::Database, bool, Flush);
+	auto_METHOD_VIRTUAL_const_(SerializerDatabase, Resource::Database, const char16_t*, GetLocation);
+	auto_METHOD_VIRTUAL(SerializerDatabase, Resource::Database, bool, SetLocation,
+		Args(const char16_t* path),
+		Args(path));
+	auto_METHOD_VIRTUAL(SerializerDatabase, Resource::Database, size_t, GetKeyList,
+		Args(eastl::vector<ResourceKey>& dstVector, Resource::IKeyFilter* filter),
+		Args(dstVector, filter));
+	auto_METHOD_VIRTUAL(SerializerDatabase, Resource::Database, bool, OpenRecord,
+		Args(const ResourceKey& name, Resource::IRecord** ppDst, IO::AccessFlags desiredAccess, IO::CD createDisposition, bool arg_10, Resource::RecordInfo* pDstInfo),
+		Args(name, ppDst, desiredAccess, createDisposition, arg_10, pDstInfo));
+	auto_METHOD_VIRTUAL(SerializerDatabase, Resource::Database, int, GetOpenCount,
+		Args(const ResourceKey& key),
+		Args(key));
+	auto_METHOD_VIRTUAL(SerializerDatabase, Resource::Database, bool, CloseRecord,
+		Args(Resource::IRecord* pRecord),
+		Args(pRecord));
+	auto_METHOD_VIRTUAL(SerializerDatabase, Resource::Database, bool, DeleteRecord,
+		Args(const ResourceKey& name),
+		Args(name));
+	auto_METHOD_VIRTUAL(SerializerDatabase, Resource::Database, bool, Attach,
+		Args(bool arg_0, Resource::IResourceManager* pResourceMan, bool arg_8),
+		Args(arg_0, pResourceMan, arg_8));
+	auto_METHOD_VIRTUAL_const_(SerializerDatabase, Resource::Database, ICoreAllocator*, GetAllocator);
+
+	auto_METHOD_VIRTUAL(SerializerDatabase, SerializerDatabase, bool, OpenAsSerializer,
+		Args(bool bOpenForReading, bool bOpenForWriting),
+		Args(bOpenForReading, bOpenForWriting));
+
+#endif
 
 }

--- a/Spore ModAPI/SourceCode/Simulator/Serialization.cpp
+++ b/Spore ModAPI/SourceCode/Simulator/Serialization.cpp
@@ -47,8 +47,6 @@ namespace Simulator
 
 #ifndef MODAPI_DLL_EXPORT
 
-	ICOMSerializer::~ICOMSerializer() = default;
-
 	COMSerializer::COMSerializer(ISerializerDatabase* pDatabase)
 		: mbBusyWritingClassObjects(false)
 		, mClassIDMapForWriting()
@@ -63,8 +61,6 @@ namespace Simulator
 		mpDatabase = pDatabase;
 	}
 
-	COMSerializer::~COMSerializer() = default;
-
 	int COMSerializer::AddRef()
 	{
 		return DefaultRefCounted::AddRef();
@@ -78,12 +74,13 @@ namespace Simulator
 	void* COMSerializer::Cast(uint32_t type) const
 	{
 		CLASS_CAST(ICOMSerializer);
+		CLASS_CAST(Object);
 		return nullptr;
 	}
 
 	auto_METHOD_VIRTUAL(COMSerializer, ICOMSerializer, bool, Open,
-		Args(ISerializerDatabase* pDatabase),
-		Args(pDatabase));
+		Args(ISerializerDatabase* pDatabase, int mode_DEPRECATED),
+		Args(pDatabase, mode_DEPRECATED));
 	auto_METHOD_VIRTUAL_(COMSerializer, ICOMSerializer, bool, Close);
 	auto_METHOD_VIRTUAL(COMSerializer, ICOMSerializer, bool, LoadClassObjects,
 		Args(uint32_t clientVersion),
@@ -118,8 +115,6 @@ namespace Simulator
 
 	}
 
-	SerializerDatabase::~SerializerDatabase() = default;
-
 	int SerializerDatabase::AddRef()
 	{
 		return Database::AddRef();
@@ -133,7 +128,9 @@ namespace Simulator
 	void* SerializerDatabase::Cast(uint32_t type) const
 	{
 		CLASS_CAST(ISerializerDatabase);
-		return nullptr;
+		return (type == Object::TYPE)
+			? (void*)this
+			: nullptr;
 	}
 
 	auto_METHOD_VIRTUAL_(SerializerDatabase, ISerializerDatabase, Resource::Database*, AsDatabase);
@@ -202,6 +199,175 @@ namespace Simulator
 	auto_METHOD_VIRTUAL(SerializerDatabase, SerializerDatabase, bool, OpenAsSerializer,
 		Args(bool bOpenForReading, bool bOpenForWriting),
 		Args(bOpenForReading, bOpenForWriting));
+
+	SerializerReadStream::SerializerReadStream()
+		: mbOK(true)
+		, mVersion(0)
+		, mpRecord(nullptr)
+		, mpDatabase(nullptr)
+	{
+
+	}
+
+	void* SerializerReadStream::Cast(uint32_t type) const
+	{
+		CLASS_CAST(ISerializerReadStream);
+		CLASS_CAST(Object);
+		return nullptr;
+	}
+
+	auto_METHOD_VIRTUAL(SerializerReadStream, ISerializerReadStream, bool, Open,
+		Args(ISerializerDatabase* pDatabase, const ResourceKey& key),
+		Args(pDatabase, key));
+	auto_METHOD_VIRTUAL_(SerializerReadStream, ISerializerReadStream, bool, Close);
+	auto_METHOD_VIRTUAL_const_(SerializerReadStream, ISerializerReadStream, bool, IsOpen);
+	auto_METHOD_VIRTUAL_const_(SerializerReadStream, ISerializerReadStream, bool, IsGood);
+	auto_METHOD_VIRTUAL_const_(SerializerReadStream, ISerializerReadStream, Resource::IRecord*, GetRecord);
+	auto_METHOD_VIRTUAL_const_(SerializerReadStream, ISerializerReadStream, ISerializerDatabase*, GetDatabase);
+	auto_METHOD_VIRTUAL(SerializerReadStream, ISerializerReadStream, bool, ReadObjectPointer,
+		Args(uint32_t castTypeID, ObjectPtr& dst, bool bLoadImmediately),
+		Args(castTypeID, dst, bLoadImmediately));
+	auto_METHOD_VIRTUAL(SerializerReadStream, ISerializerReadStream, bool, ReadPointer,
+		Args(ISimulatorSerializable* pointer, bool bLoadImmediately),
+		Args(pointer, bLoadImmediately));
+	auto_METHOD_VIRTUAL(SerializerReadStream, ISerializerReadStream, bool, ReadProperty,
+		Args(App::Property& dst),
+		Args(dst));
+	auto_METHOD_VIRTUAL(SerializerReadStream, ISerializerReadStream, bool, ReadRawData,
+		Args(void* pBuffer, size_t size),
+		Args(pBuffer, size));
+	auto_METHOD_VIRTUAL(SerializerReadStream, ISerializerReadStream, bool, ReadPropertyByID,
+		Args(uint32_t propertyID, App::Property& dst),
+		Args(propertyID, dst));
+	auto_METHOD_VIRTUAL_const_(SerializerReadStream, ISerializerReadStream, uint32_t, GetSerializationVersion);
+	auto_METHOD_VIRTUAL_VOID(SerializerReadStream, ISerializerReadStream, SetSerializationVersion,
+		Args(uint32_t version),
+		Args(version));
+
+	auto_METHOD_VIRTUAL(SerializerReadStream, ISerializerReadStream, bool, Skip,
+		Args(const uint32_t skipCount),
+		Args(skipCount));
+
+	SerializerWriteStream::SerializerWriteStream()
+		: mpRecord(nullptr)
+		, mpDatabase(nullptr)
+		, mbOK(true)
+	{
+
+	}
+
+	void* SerializerWriteStream::Cast(uint32_t type) const
+	{
+		CLASS_CAST(SerializerWriteStream);
+		CLASS_CAST(Object);
+		return nullptr;
+	}
+
+	auto_METHOD_VIRTUAL(SerializerWriteStream, ISerializerWriteStream, bool, Open,
+		Args(ISerializerDatabase* pDatabase, const ResourceKey& key, bool bTruncate),
+		Args(pDatabase, key, bTruncate));
+	auto_METHOD_VIRTUAL_(SerializerWriteStream, ISerializerWriteStream, bool, Close);
+	auto_METHOD_VIRTUAL_const_(SerializerWriteStream, ISerializerWriteStream, bool, IsOpen);
+	auto_METHOD_VIRTUAL_const_(SerializerWriteStream, ISerializerWriteStream, bool, IsGood);
+	auto_METHOD_VIRTUAL_const_(SerializerWriteStream, ISerializerWriteStream, Resource::IRecord*, GetRecord);
+	auto_METHOD_VIRTUAL_const_(SerializerWriteStream, ISerializerWriteStream, ISerializerDatabase*, GetDatabase);
+	auto_METHOD_VIRTUAL(SerializerWriteStream, ISerializerWriteStream, bool, WriteObjectPointer,
+		Args(Object* pObject),
+		Args(pObject));
+	auto_METHOD_VIRTUAL(SerializerWriteStream, ISerializerWriteStream, bool, WritePointer,
+		Args(ISimulatorSerializable* pointer),
+		Args(pointer));
+	auto_METHOD_VIRTUAL(SerializerWriteStream, ISerializerWriteStream, bool, WriteProperty,
+		Args(App::Property& src),
+		Args(src));
+	auto_METHOD_VIRTUAL(SerializerWriteStream, ISerializerWriteStream, bool, WriteRawData,
+		Args(void* pData, size_t size),
+		Args(pData, size));
+	auto_METHOD_VIRTUAL(SerializerWriteStream, ISerializerWriteStream, bool, WritePropertyWithID,
+		Args(uint32_t propertyID, App::Property& src),
+		Args(propertyID, src));
+
+	SerializerReadStreamPrivate::SerializerReadStreamPrivate(ISerializerDatabase* pDatabase, uint32_t nResourceType, uint32_t nInstance, uint32_t nGroupID)
+		: mpDatabase(nullptr)
+		, mpReadStream(nullptr)
+	{
+		openStream(pDatabase, nResourceType, nInstance, nGroupID);
+	}
+
+	SerializerReadStreamPrivate::SerializerReadStreamPrivate(ISerializerReadStream& readStream, uint32_t nResourceType, uint32_t nInstance, uint32_t nGroupID)
+		: SerializerReadStreamPrivate(readStream.GetDatabase(), nResourceType, nInstance, nGroupID)
+	{
+
+	}
+
+	SerializerReadStreamPrivate::SerializerReadStreamPrivate(ISerializerDatabase* pDatabase, const ResourceKey& key)
+		: SerializerReadStreamPrivate(pDatabase, key.typeID, key.instanceID, key.groupID)
+	{
+
+	}
+
+	SerializerReadStreamPrivate::SerializerReadStreamPrivate(ISerializerReadStream& readStream, const ResourceKey& key)
+		: SerializerReadStreamPrivate(readStream, key.typeID, key.instanceID, key.groupID)
+	{
+
+	}
+
+	SerializerReadStreamPrivate::~SerializerReadStreamPrivate()
+	{
+		if (mpReadStream && mpReadStream->IsOpen())
+		{
+			mpReadStream->Close();
+		}
+	}
+
+	auto_METHOD_(SerializerReadStreamPrivate, bool, IsOpen);
+	auto_METHOD_VOID(SerializerReadStreamPrivate, SetSerializationVersion,
+		Args(uint32_t version),
+		Args(version));
+	auto_METHOD_const_(SerializerReadStreamPrivate, uint32_t, GetSerializationVersion);
+
+	auto_METHOD(SerializerReadStreamPrivate, bool, openStream,
+		Args(ISerializerDatabase* pDatabase, uint32_t nResourceType, uint32_t nInstance, uint32_t nGroupID),
+		Args(pDatabase, nResourceType, nInstance, nGroupID));
+
+	SerializerWriteStreamPrivate::SerializerWriteStreamPrivate(ISerializerDatabase* pDatabase, uint32_t nResourceType, uint32_t nInstance, uint32_t nGroupID)
+		: mpDatabase(nullptr)
+		, mpWriteStream(nullptr)
+	{
+		openStream(pDatabase, nResourceType, nInstance, nGroupID);
+	}
+
+	SerializerWriteStreamPrivate::SerializerWriteStreamPrivate(ISerializerWriteStream& writeStream, uint32_t nResourceType, uint32_t nInstance, uint32_t nGroupID)
+		: SerializerWriteStreamPrivate(writeStream.GetDatabase(), nResourceType, nInstance, nGroupID)
+	{
+
+	}
+
+	SerializerWriteStreamPrivate::SerializerWriteStreamPrivate(ISerializerDatabase* pDatabase, const ResourceKey& key)
+		: SerializerWriteStreamPrivate(pDatabase, key.typeID, key.instanceID, key.groupID)
+	{
+
+	}
+
+	SerializerWriteStreamPrivate::SerializerWriteStreamPrivate(ISerializerWriteStream& writeStream, const ResourceKey& key)
+		: SerializerWriteStreamPrivate(writeStream, key.typeID, key.instanceID, key.groupID)
+	{
+
+	}
+
+	SerializerWriteStreamPrivate::~SerializerWriteStreamPrivate()
+	{
+		if (mpWriteStream && mpWriteStream->IsOpen())
+		{
+			mpWriteStream->Close();
+		}
+	}
+
+	auto_METHOD_(SerializerWriteStreamPrivate, bool, IsOpen);
+
+	auto_METHOD(SerializerWriteStreamPrivate, bool, openStream,
+		Args(ISerializerDatabase* pDatabase, uint32_t nResourceType, uint32_t nInstance, uint32_t nGroupID),
+		Args(pDatabase, nResourceType, nInstance, nGroupID));
 
 #endif
 

--- a/Spore ModAPI/Spore/App/Property.h
+++ b/Spore ModAPI/Spore/App/Property.h
@@ -52,7 +52,10 @@ namespace App
 		BBox = 0x39,
 		// Unseen types
 		Char = 0x0002,
+		Char8 = Char,
 		WChar = 0x0003,
+		Char16 = WChar,
+		Char32 = 0x0004,
 		Int8 = 0x0005,
 		UInt8 = 0x0006,
 		Int16 = 0x0007,
@@ -61,6 +64,7 @@ namespace App
 		UInt64 = 0x000C,
 		Double = 0x000E,
 		Ptr = 0x000F,
+		String32 = 0x0014,
 		// only this one is used in Spore code, but not in files
 		Void = 0x0010,
 		IUnknownRC = 0x0011,

--- a/Spore ModAPI/Spore/App/Thumbnail_cImportExport.h
+++ b/Spore ModAPI/Spore/App/Thumbnail_cImportExport.h
@@ -21,6 +21,7 @@ namespace App
 			kImageFormatBMP
 		};
 
+		bool ReadImageData(IO::IStream* inputStream);
 		bool WriteImageToStream(IO::IStream* outputStream, Format format);
 
 		/* 00h */	eastl::vector<int> mPixelBuf;
@@ -174,6 +175,7 @@ namespace App
 
 	namespace Addresses(PngEncoder)
 	{
+		DeclareAddress(ReadImageData);
 		DeclareAddress(WriteImageToStream);  // 0x68E660 0x68e190
 	}
 }

--- a/Spore ModAPI/Spore/IO/IniFile.h
+++ b/Spore ModAPI/Spore/IO/IniFile.h
@@ -28,10 +28,10 @@ namespace IO
 		/* 08h */	virtual void SetOption(Options option, int value);
 		/* 0Ch */	virtual wchar_t const* GetPath() const;
 		/* 10h */	virtual bool SetPath(const wchar_t* pPath);
-		/* 14h */	virtual class IStream* GetStream() const;
+		/* 14h */	virtual IStream* GetStream() const;
 		/* 18h */	virtual bool SetStream(IStream* pStream);
 		/* 1Ch */	virtual bool Close();
-		/* 20h */	virtual int ReadEntry(const wchar_t* pSection, const wchar_t* pKey, class eastl::basic_string<wchar_t>& sValue);
+		/* 20h */	virtual int ReadEntry(const wchar_t* pSection, const wchar_t* pKey, eastl::basic_string<wchar_t>& sValue);
 		/* 24h */	virtual int ReadEntryToBuffer(const wchar_t* pSection, const wchar_t* pKey, wchar_t* pValue, uint32_t nValueLength);
 		// Stub, do not detour.
 		/* 28h */	virtual int ReadEntryFormatted(const wchar_t* pSection, const wchar_t* pKey, const wchar_t* pValueFormat, ...);
@@ -47,9 +47,9 @@ namespace IO
 		/* 48h */	virtual bool Open(int nAccessFlags);
 		/* 4Ch */	virtual int GetEncoding();
 		/* 50h */	virtual bool LoadSectionNames(int nAccessFlags);
-		/* 54h */	virtual bool GetFileLine8To8(class eastl::basic_string<char>& sLine);
-		/* 58h */	virtual bool GetFileLine16To16(class eastl::basic_string<wchar_t>& sLine);
-		/* 5Ch */	virtual bool GetFileLine(class eastl::basic_string<wchar_t>& sLine);
+		/* 54h */	virtual bool GetFileLine8To8(eastl::basic_string<char>& sLine);
+		/* 58h */	virtual bool GetFileLine16To16(eastl::basic_string<wchar_t>& sLine);
+		/* 5Ch */	virtual bool GetFileLine(eastl::basic_string<wchar_t>& sLine);
 		/* 60h */	virtual bool ConvertAndWriteStream(const wchar_t* pchar, uint32_t count);
 
 		/* 04h */	wchar_t mPath[260];

--- a/Spore ModAPI/Spore/IO/IniFile.h
+++ b/Spore ModAPI/Spore/IO/IniFile.h
@@ -23,7 +23,7 @@ namespace IO
 		IniFile(const wchar_t* pPath, int optionFlags);
 		IniFile(IStream* pStream);
 
-		/* 00h */	virtual ~IniFile() final = default;
+		/* 00h */	virtual ~IniFile() final;
 		/* 04h */	virtual int GetOption(Options option) const;
 		/* 08h */	virtual void SetOption(Options option, int value);
 		/* 0Ch */	virtual wchar_t const* GetPath() const;

--- a/Spore ModAPI/Spore/Resource/Database.h
+++ b/Spore ModAPI/Spore/Resource/Database.h
@@ -44,7 +44,7 @@ namespace Resource
 		/* 0Ch */	virtual uint32_t GetDatabaseType() const = 0;
 		/* 10h */	virtual int GetRefCount() const = 0;
 		/* 14h */	virtual void Lock(bool lock) = 0;
-		/* 18h */	virtual bool Open(IO::AccessFlags desiredAccess = IO::AccessFlags::Read, IO::CD createDisposition = IO::CD::Default, bool arg_8 = false) = 0;
+		/* 18h */	virtual bool Open(IO::AccessFlags desiredAccess = IO::AccessFlags::Read, IO::CD createDisposition = IO::CD::Default, bool bAutoOpen = false) = 0;
 		/* 1Ch */	virtual bool Close() = 0;
 		/* 20h */	virtual IO::AccessFlags GetAccessFlags() const = 0;
 		/* 24h */	virtual bool Flush() = 0;

--- a/Spore ModAPI/Spore/Resource/DatabaseDirectoryFiles.h
+++ b/Spore ModAPI/Spore/Resource/DatabaseDirectoryFiles.h
@@ -36,7 +36,7 @@ namespace Resource
 		/* 0Ch */	virtual uint32_t GetDatabaseType() const override;
 		/* 10h */	virtual int GetRefCount() const override;
 		/* 14h */	virtual void Lock(bool lock) override;
-		/* 18h */	virtual bool Open(IO::AccessFlags desiredAccess = IO::AccessFlags::Read, IO::CD createDisposition = IO::CD::Default, bool arg_8 = false) override;
+		/* 18h */	virtual bool Open(IO::AccessFlags desiredAccess = IO::AccessFlags::Read, IO::CD createDisposition = IO::CD::Default, bool bAutoOpen = false) override;
 		/* 1Ch */	virtual bool Close() override;
 		/* 20h */	virtual IO::AccessFlags GetAccessFlags() const override;
 		/* 24h */	virtual bool Flush() override;

--- a/Spore ModAPI/Spore/Resource/DatabasePackedFile.h
+++ b/Spore ModAPI/Spore/Resource/DatabasePackedFile.h
@@ -82,7 +82,7 @@ namespace Resource
 		/* 0Ch */	virtual uint32_t GetDatabaseType() const override;
 		/* 10h */	virtual int GetRefCount() const override;
 		/* 14h */	virtual void Lock(bool lock) override;
-		/* 18h */	virtual bool Open(IO::AccessFlags desiredAccess = IO::AccessFlags::Read, IO::CD createDisposition = IO::CD::Default, bool arg_8 = false) override;
+		/* 18h */	virtual bool Open(IO::AccessFlags desiredAccess = IO::AccessFlags::Read, IO::CD createDisposition = IO::CD::Default, bool bAutoOpen = false) override;
 		/* 1Ch */	virtual bool Close() override;
 		/* 20h */	virtual IO::AccessFlags GetAccessFlags() const override;
 		/* 24h */	virtual bool Flush() override;

--- a/Spore ModAPI/Spore/Simulator/ISimulatorSerializable.h
+++ b/Spore ModAPI/Spore/Simulator/ISimulatorSerializable.h
@@ -19,12 +19,14 @@
 #pragma once
 
 #include <Spore\Object.h>
-#include <Spore\Simulator\Serialization.h>
 
 #define ISimulatorSerializablePtr eastl::intrusive_ptr<Simulator::ISimulatorSerializable>
 
 namespace Simulator
 {
+	class ISerializerStream;
+	class XmlSerializer;
+
 	class ISimulatorSerializable
 		: public Object
 	{

--- a/Spore ModAPI/Spore/Simulator/Serialization.h
+++ b/Spore ModAPI/Spore/Simulator/Serialization.h
@@ -12,6 +12,11 @@
 #define ISerializerWriteStreamPtr eastl::intrusive_ptr<Simulator::ISerializerWriteStream>
 #define ICOMSerializerPtr eastl::intrusive_ptr<Simulator::ICOMSerializer>
 
+#define SerializerDatabasePtr eastl::intrusive_ptr<Simulator::SerializerDatabase>
+#define SerializerReadStreamPtr eastl::intrusive_ptr<Simulator::SerializerReadStream>
+#define SerializerWriteStreamPtr eastl::intrusive_ptr<Simulator::SerializerWriteStream>
+#define COMSerializerPtr eastl::intrusive_ptr<Simulator::COMSerializer>
+
 namespace Simulator
 {
 	class ICOMSerializer;
@@ -54,13 +59,16 @@ namespace Simulator
 		/* 1Ch */	virtual bool IsGood() const = 0;
 		/* 20h */	virtual Resource::IRecord* GetRecord() const = 0;
 		/* 24h */	virtual ISerializerDatabase* GetDatabase() const = 0;
-		/* 28h */	virtual bool ReadObjectPointer(uint32_t castTypeID, ObjectPtr& dst, int) = 0;
-		/* 2Ch */	virtual bool ReadPointer(ISimulatorSerializable* pointer) = 0;
+		/* 28h */	virtual bool ReadObjectPointer(uint32_t castTypeID, ObjectPtr& dst, bool bLoadImmediately) = 0;
+		/* 2Ch */	virtual bool ReadPointer(ISimulatorSerializable* pointer, bool bLoadImmediately) = 0;
 		/* 30h */	virtual bool ReadProperty(App::Property& dst) = 0;
 		/* 34h */	virtual bool ReadRawData(void* pBuffer, size_t size) = 0;
+	protected:
+		// Deprecated.
 		/* 38h */	virtual bool ReadPropertyByID(uint32_t propertyID, App::Property& dst) = 0;
+	public:
 		/* 3Ch */	virtual uint32_t GetSerializationVersion() const = 0;
-		/* 40h */	virtual void SetSerializationVersion(uint32_t) = 0;
+		/* 40h */	virtual void SetSerializationVersion(uint32_t version) = 0;
 	};
 
 	class ISerializerWriteStream
@@ -71,7 +79,7 @@ namespace Simulator
 
 		/* 10h */	virtual bool Open(ISerializerDatabase* pDatabase, const ResourceKey& key, bool bTruncate) = 0;
 		/* 14h */	virtual bool Close() = 0;
-		/* 18h */	virtual int IsOpen() const = 0;
+		/* 18h */	virtual bool IsOpen() const = 0;
 		/* 1Ch */	virtual bool IsGood() const = 0;
 		/* 20h */	virtual Resource::IRecord* GetRecord() const = 0;
 		/* 24h */	virtual ISerializerDatabase* GetDatabase() const = 0;
@@ -79,6 +87,8 @@ namespace Simulator
 		/* 2Ch */	virtual bool WritePointer(ISimulatorSerializable* pointer) = 0;
 		/* 30h */	virtual bool WriteProperty(App::Property& src) = 0;
 		/* 34h */	virtual bool WriteRawData(void* pData, size_t size) = 0;
+	protected:
+		// Deprecated.
 		/* 38h */	virtual bool WritePropertyWithID(uint32_t propertyID, App::Property& src) = 0;
 	};
 
@@ -95,9 +105,7 @@ namespace Simulator
 			kRecordTypeID_Classes = 0x179D310
 		};
 
-		/* 08h */	virtual ~ICOMSerializer();
-
-		/* 10h */	virtual bool Open(ISerializerDatabase* pDatabase) = 0;
+		/* 10h */	virtual bool Open(ISerializerDatabase* pDatabase, int mode_DEPRECATED) = 0;
 		/* 14h */	virtual bool Close() = 0;
 		/* 18h */	virtual bool LoadClassObjects(uint32_t clientVersion) = 0;
 		/* 1Ch */	virtual bool SaveClassObjects() = 0;
@@ -217,11 +225,11 @@ namespace Simulator
 	public:
 		COMSerializer(ISerializerDatabase* pDatabase);
 
-		virtual ~COMSerializer();
 		virtual int AddRef() override;
 		virtual int Release() override;
 		virtual void* Cast(uint32_t type) const override;
-		virtual bool Open(ISerializerDatabase* pDatabase) override;
+
+		virtual bool Open(ISerializerDatabase* pDatabase, int mode_DEPRECATED) override;
 		virtual bool Close() override;
 		virtual bool LoadClassObjects(uint32_t clientVersion) override;
 		virtual bool SaveClassObjects() override;
@@ -282,7 +290,6 @@ namespace Simulator
 	public:
 		SerializerDatabase(Resource::Database* pDatabase);
 
-		virtual ~SerializerDatabase();
 		virtual int AddRef() override;
 		virtual int Release() override;
 		virtual void* Cast(uint32_t type) const override;
@@ -364,6 +371,157 @@ namespace Simulator
 		DeclareAddress(Attach);
 		DeclareAddress(GetAllocator);
 		DeclareAddress(OpenAsSerializer);
+	}
+
+	class SerializerReadStream
+		: DefaultRefCounted
+		, ISerializerReadStream
+	{
+	public:
+		SerializerReadStream();
+
+		virtual void* Cast(uint32_t type) const override;
+
+		virtual bool Open(ISerializerDatabase* pDatabase, const ResourceKey& key) override;
+		virtual bool Close() override;
+		virtual bool IsOpen() const override;
+		virtual bool IsGood() const override;
+		virtual Resource::IRecord* GetRecord() const override;
+		virtual ISerializerDatabase* GetDatabase() const override;
+		virtual bool ReadObjectPointer(uint32_t castTypeID, ObjectPtr& dst, bool bLoadImmediately) override;
+		virtual bool ReadPointer(ISimulatorSerializable* pointer, bool bLoadImmediately) override;
+		virtual bool ReadProperty(App::Property& dst) override;
+		virtual bool ReadRawData(void* pBuffer, size_t size) override;
+	protected:
+		// Deprecated.
+		virtual bool ReadPropertyByID(uint32_t propertyID, App::Property& dst) override;
+	public:
+		virtual uint32_t GetSerializationVersion() const override;
+		virtual void SetSerializationVersion(uint32_t version) override;
+
+		virtual bool Skip(const uint32_t skipCount);
+	protected:
+		/* 0Ch */	bool mbOK;
+		/* 10h */	uint32_t mVersion;
+		/* 14h */	eastl::intrusive_ptr<Resource::IRecord> mpRecord;
+		/* 18h */	eastl::intrusive_ptr<ISerializerDatabase> mpDatabase;
+	};
+	ASSERT_SIZE(SerializerReadStream, 0x1C);
+
+	namespace Addresses(SerializerReadStream)
+	{
+		DeclareAddress(Open);
+		DeclareAddress(Close);
+		DeclareAddress(IsOpen);
+		DeclareAddress(IsGood);
+		DeclareAddress(GetRecord);
+		DeclareAddress(GetDatabase);
+		DeclareAddress(ReadObjectPointer);
+		DeclareAddress(ReadPointer);
+		DeclareAddress(ReadProperty);
+		DeclareAddress(ReadRawData);
+		DeclareAddress(ReadPropertyByID);
+		DeclareAddress(GetSerializationVersion);
+		DeclareAddress(SetSerializationVersion);
+		DeclareAddress(Skip);
+	}
+
+	class SerializerWriteStream
+		: DefaultRefCounted
+		, ISerializerWriteStream
+	{
+	public:
+		SerializerWriteStream();
+
+		virtual void* Cast(uint32_t type) const override;
+
+		virtual bool Open(ISerializerDatabase* pDatabase, const ResourceKey& key, bool bTruncate) override;
+		virtual bool Close() override;
+		virtual bool IsOpen() const override;
+		virtual bool IsGood() const override;
+		virtual Resource::IRecord* GetRecord() const override;
+		virtual ISerializerDatabase* GetDatabase() const override;
+		virtual bool WriteObjectPointer(Object* pObject) override;
+		virtual bool WritePointer(ISimulatorSerializable* pointer) override;
+		virtual bool WriteProperty(App::Property& src) override;
+		virtual bool WriteRawData(void* pData, size_t size) override;
+	protected:
+		// Deprecated.
+		virtual bool WritePropertyWithID(uint32_t propertyID, App::Property& src) override;
+
+		/* 0Ch */	eastl::intrusive_ptr<Resource::IRecord> mpRecord;
+		/* 10h */	eastl::intrusive_ptr<ISerializerDatabase> mpDatabase;
+		/* 14h */	bool mbOK;
+	};
+	ASSERT_SIZE(SerializerWriteStream, 0x18);
+
+	namespace Addresses(SerializerWriteStream)
+	{
+		DeclareAddress(Open);
+		DeclareAddress(Close);
+		DeclareAddress(IsOpen);
+		DeclareAddress(IsGood);
+		DeclareAddress(GetRecord);
+		DeclareAddress(GetDatabase);
+		DeclareAddress(WriteObjectPointer);
+		DeclareAddress(WritePointer);
+		DeclareAddress(WriteProperty);
+		DeclareAddress(WriteRawData);
+		DeclareAddress(WritePropertyWithID);
+	}
+
+	class SerializerReadStreamPrivate
+	{
+	public:
+		SerializerReadStreamPrivate(ISerializerReadStream& readStream, const ResourceKey& key);
+		SerializerReadStreamPrivate(ISerializerDatabase* pDatabase, const ResourceKey& key);
+		SerializerReadStreamPrivate(ISerializerReadStream& readStream, uint32_t nResourceType, uint32_t nInstance, uint32_t nGroupID);
+		SerializerReadStreamPrivate(ISerializerDatabase* pDatabase, uint32_t nResourceType, uint32_t nInstance, uint32_t nGroupID);
+
+		virtual ~SerializerReadStreamPrivate();
+
+		bool IsOpen();
+		void SetSerializationVersion(uint32_t version);
+		uint32_t GetSerializationVersion() const;
+
+		/* 04h */	eastl::intrusive_ptr<ISerializerDatabase> mpDatabase;
+		/* 08h */	eastl::intrusive_ptr<ISerializerReadStream> mpReadStream;
+	protected:
+		bool openStream(ISerializerDatabase* pDatabase, uint32_t nResourceType, uint32_t nInstance, uint32_t nGroupID);
+	};
+	ASSERT_SIZE(SerializerReadStreamPrivate, 0xC);
+
+	namespace Addresses(SerializerReadStreamPrivate)
+	{
+		DeclareAddress(IsOpen);
+		DeclareAddress(SetSerializationVersion);
+		DeclareAddress(GetSerializationVersion);
+		DeclareAddress(openStream);
+	}
+
+	class SerializerWriteStreamPrivate
+	{
+	public:
+		SerializerWriteStreamPrivate(ISerializerWriteStream& writeStream, const ResourceKey& key);
+		SerializerWriteStreamPrivate(ISerializerDatabase* pDatabase, const ResourceKey& key);
+		SerializerWriteStreamPrivate(ISerializerWriteStream& writeStream, uint32_t nResourceType, uint32_t nInstance, uint32_t nGroupID);
+		SerializerWriteStreamPrivate(ISerializerDatabase* pDatabase, uint32_t nResourceType, uint32_t nInstance, uint32_t nGroupID);
+
+		virtual ~SerializerWriteStreamPrivate();
+
+		bool IsOpen();
+
+		/* 04h */	eastl::intrusive_ptr<ISerializerDatabase> mpDatabase;
+		/* 08h */	eastl::intrusive_ptr<ISerializerWriteStream> mpWriteStream;
+	protected:
+		bool openStream(ISerializerDatabase* pDatabase, uint32_t nResourceType, uint32_t nInstance, uint32_t nGroupID);
+	};
+	ASSERT_SIZE(SerializerWriteStreamPrivate, 0xC);
+
+	namespace Addresses(SerializerWriteStreamPrivate)
+	{
+		DeclareAddress(IsOpen);
+		DeclareAddress(openStream);
 	}
 }
 

--- a/Spore ModAPI/Spore/Simulator/Serialization.h
+++ b/Spore ModAPI/Spore/Simulator/Serialization.h
@@ -1,14 +1,44 @@
 #pragma once
 
+#include <EASTL\map.h>
+#include <Spore\App\Property.h>
 #include <Spore\Resource\IRecord.h>
+#include <Spore\Resource\Database.h>
 #include <Spore\Object.h>
+#include <Spore\Simulator\ISimulatorSerializable.h>
+
+#define ISerializerDatabasePtr eastl::intrusive_ptr<Simulator::ISerializerDatabase>
+#define ISerializerReadStreamPtr eastl::intrusive_ptr<Simulator::ISerializerReadStream>
+#define ISerializerWriteStreamPtr eastl::intrusive_ptr<Simulator::ISerializerWriteStream>
+#define ICOMSerializerPtr eastl::intrusive_ptr<Simulator::ICOMSerializer>
 
 namespace Simulator
 {
-	class ISimulatorSerializable;
+	class ICOMSerializer;
+	class ISerializerReadStream;
+	class ISerializerWriteStream;
 
-	// This is a dirty workaround: it might not exist, but all existing classes and item templates use it
-	class ISerializerStream : public Object
+	class ISerializerDatabase
+		: public Object
+	{
+	public:
+		static const uint32_t TYPE = 0x19DA51A;
+
+		/* 10h */	virtual Resource::Database* AsDatabase() = 0;
+		/* 14h */	virtual ICOMSerializer* GetCOMSerializer() = 0;
+		/* 18h */	virtual bool OpenReadStream(const ResourceKey& key, ISerializerReadStream** ppStream) = 0;
+		/* 1Ch */	virtual bool CloseReadStream(ISerializerReadStream* pStream) = 0;
+		/* 20h */	virtual bool LoadClassObjects(uint32_t version) = 0;
+		/* 24h */	virtual bool OpenWriteStream(const ResourceKey& key, ISerializerWriteStream** ppStream, bool bTruncate) = 0;
+		/* 28h */	virtual bool CloseWriteStream(ISerializerWriteStream* pStream) = 0;
+		/* 2Ch */	virtual bool SaveClassObjects() = 0;
+		/* 30h */	virtual bool HasKey(const ResourceKey& key) const = 0;
+		/* 34h */	virtual float GetPercentageCompletion() const = 0;
+		/* 38h */	virtual void SetPercentageCompletion(float fPercentageCompletion0To100) = 0;
+	};
+
+	class ISerializerStream
+		: public Object
 	{
 	};
 
@@ -18,19 +48,19 @@ namespace Simulator
 	public:
 		static const uint32_t TYPE = 0x179CD60;
 
-		/* 10h */	virtual bool func10h(int, const ResourceKey& name) = 0;
-		/* 14h */	virtual bool func14h() = 0;
-		/* 18h */	virtual bool func18h() = 0;
-		/* 1Ch */	virtual bool func1Ch() = 0;
+		/* 10h */	virtual bool Open(ISerializerDatabase* pDatabase, const ResourceKey& key) = 0;
+		/* 14h */	virtual bool Close() = 0;
+		/* 18h */	virtual bool IsOpen() const = 0;
+		/* 1Ch */	virtual bool IsGood() const = 0;
 		/* 20h */	virtual Resource::IRecord* GetRecord() const = 0;
-		/* 24h */	virtual int func24h() const = 0;
-		/* 28h */	virtual bool ReadPointer(uint32_t castTypeID, eastl::intrusive_ptr<Object>& dst, int) = 0;
-		/* 2Ch */	virtual bool WritePointer(ISimulatorSerializable* pointer) = 0;
-		/* 30h */	virtual bool func30h(int) = 0;  // related with prop files?
-		/* 34h */	virtual bool func34h(int, int) = 0;
-		/* 38h */	virtual bool func38h(int, int) = 0;
-		/* 3Ch */	virtual int func3Ch() = 0;
-		/* 40h */	virtual void func40h(int) = 0;
+		/* 24h */	virtual ISerializerDatabase* GetDatabase() const = 0;
+		/* 28h */	virtual bool ReadObjectPointer(uint32_t castTypeID, ObjectPtr& dst, int) = 0;
+		/* 2Ch */	virtual bool ReadPointer(ISimulatorSerializable* pointer) = 0;
+		/* 30h */	virtual bool ReadProperty(App::Property& dst) = 0;
+		/* 34h */	virtual bool ReadRawData(void* pBuffer, size_t size) = 0;
+		/* 38h */	virtual bool ReadPropertyByID(uint32_t propertyID, App::Property& dst) = 0;
+		/* 3Ch */	virtual uint32_t GetSerializationVersion() const = 0;
+		/* 40h */	virtual void SetSerializationVersion(uint32_t) = 0;
 	};
 
 	class ISerializerWriteStream
@@ -39,17 +69,40 @@ namespace Simulator
 	public:
 		static const uint32_t TYPE = 0x179CD61;
 
-		/* 10h */	virtual bool func10h(int, int, int) = 0;
-		/* 14h */	virtual bool func14h() = 0;
-		/* 18h */	virtual int func18h() = 0;
-		/* 1Ch */	virtual bool func1Ch() = 0;
+		/* 10h */	virtual bool Open(ISerializerDatabase* pDatabase, const ResourceKey& key, bool bTruncate) = 0;
+		/* 14h */	virtual bool Close() = 0;
+		/* 18h */	virtual int IsOpen() const = 0;
+		/* 1Ch */	virtual bool IsGood() const = 0;
 		/* 20h */	virtual Resource::IRecord* GetRecord() const = 0;
-		/* 24h */	virtual int func24h() const = 0;
-		/* 28h */	virtual bool WriteObjectPointer(Object* object) = 0;
+		/* 24h */	virtual ISerializerDatabase* GetDatabase() const = 0;
+		/* 28h */	virtual bool WriteObjectPointer(Object* pObject) = 0;
 		/* 2Ch */	virtual bool WritePointer(ISimulatorSerializable* pointer) = 0;
-		/* 30h */	virtual void func30h(int) = 0;
-		/* 34h */	virtual bool func34h(int, int) = 0;
-		/* 38h */	virtual bool func38h(int, int) = 0;
+		/* 30h */	virtual bool WriteProperty(App::Property& src) = 0;
+		/* 34h */	virtual bool WriteRawData(void* pData, size_t size) = 0;
+		/* 38h */	virtual bool WritePropertyWithID(uint32_t propertyID, App::Property& src) = 0;
+	};
+
+	class ICOMSerializer
+		: public Object
+	{
+	public:
+		static const uint32_t TYPE = 0x179D2A7;
+
+		enum DataIDs
+		{
+			kRecordGroupID_Default = 0x179D304,
+			kRecordInstanceID_Default = 0x0,
+			kRecordTypeID_Classes = 0x179D310
+		};
+
+		/* 08h */	virtual ~ICOMSerializer();
+
+		/* 10h */	virtual bool Open(ISerializerDatabase* pDatabase) = 0;
+		/* 14h */	virtual bool Close() = 0;
+		/* 18h */	virtual bool LoadClassObjects(uint32_t clientVersion) = 0;
+		/* 1Ch */	virtual bool SaveClassObjects() = 0;
+		/* 20h */	virtual bool Write(ISerializerWriteStream& oSPStream, const ISimulatorSerializable* pSerializable) = 0;
+		/* 24h */	virtual bool Read(ISerializerReadStream& iSPStream, const ISimulatorSerializable** ppSerializable, bool bLoadImmediately) = 0;
 	};
 
 	//class SerializerStream
@@ -116,9 +169,9 @@ namespace Simulator
 		struct AttributePointer
 		{
 			/* 00h */	uint32_t id;
-			/* 04h */	int field_4;
-			/* 08h */	bool field_8;
-			/* 0Ch */	void* field_C;   // field_18 of the attribute
+			/* 04h */	uint32_t dataSize;
+			/* 08h */	bool serialized;
+			/* 0Ch */	void* pBinderContext;   // field_18 of the attribute
 			/* 10h */	Attribute* pAttribute;
 		};
 
@@ -129,7 +182,7 @@ namespace Simulator
 		// Attributes are searched with a binary search, they must be ordered
 		AttributePointer attributes[128];
 		/* A00h */	int count;
-		/* A04h */	int field_A04;  // count of attributes written
+		/* A04h */	int countSerialized;  // count of attributes written
 		/* A08h */	uint32_t id;
 		/* A0Ch */	void* pObject;
 		/* A10h */	Attribute* pAttributes;
@@ -155,6 +208,162 @@ namespace Simulator
 	namespace Addresses(XmlSerializer)
 	{
 		DeclareAddress(AttributesToXml);
+	}
+
+	class COMSerializer
+		: public DefaultRefCounted
+		, public ICOMSerializer
+	{
+	public:
+		COMSerializer(ISerializerDatabase* pDatabase);
+
+		virtual ~COMSerializer();
+		virtual int AddRef() override;
+		virtual int Release() override;
+		virtual void* Cast(uint32_t type) const override;
+		virtual bool Open(ISerializerDatabase* pDatabase) override;
+		virtual bool Close() override;
+		virtual bool LoadClassObjects(uint32_t clientVersion) override;
+		virtual bool SaveClassObjects() override;
+		virtual bool Write(ISerializerWriteStream& oSPStream, const ISimulatorSerializable* pSerializable) override;
+		virtual bool Read(ISerializerReadStream& iSPStream, const ISimulatorSerializable** ppSerializable, bool bLoadImmediately) override;
+	protected:
+		bool GetCRC(Resource::IRecord* pRecord, uint32_t nCRCDataLength, uint32_t& nCRC);
+		void reset();
+		bool onSetSPSerializable(const ISimulatorSerializable* pSerializable, uint32_t instanceID, uint32_t classID);
+		bool onGetSPSerializable(ISimulatorSerializable** ppSerializable, uint32_t instanceID, uint32_t classID);
+		bool loadSingleObject(ISimulatorSerializable* pSerializable, uint32_t instanceID, uint32_t classID);
+
+		struct IDInfo
+		{
+			/* 00h */	eastl::intrusive_ptr<ISimulatorSerializable> mpSerializable;
+		};
+		ASSERT_SIZE(IDInfo, 0x4);
+
+		struct ClassInfo
+		{
+			/* 00h */	uint32_t mReadInstanceCount;
+			/* 04h */	uint32_t mInstanceCount;
+			/* 08h */	eastl::map<uint32_t, IDInfo, eastl::less<uint32_t>> mInstanceIDMap;
+		};
+		ASSERT_SIZE(ClassInfo, 0x24);
+
+		/* 0Ch */	bool mbBusyWritingClassObjects;
+		/* 10h */	eastl::map<uint32_t, ClassInfo, eastl::less<uint32_t>> mClassIDMapForWriting;
+		/* 2Ch */	eastl::map<uint32_t, ClassInfo, eastl::less<uint32_t>> mClassIDMap;
+		/* 48h */	int mTotalSerializableCount;
+		/* 4Ñh */	bool mbClassObjectsLoaded;
+		/* 4Dh */	bool mbClassObjectsSaved;
+		/* 50h */	ISerializerDatabasePtr mpDatabase;
+		/* 54h */	eastl::vector<uint8_t> mCRCDataBuffer;
+	};
+	ASSERT_SIZE(COMSerializer, 0x68);
+
+	namespace Addresses(COMSerializer)
+	{
+		DeclareAddress(Open);
+		DeclareAddress(Close);
+		DeclareAddress(LoadClassObjects);
+		DeclareAddress(SaveClassObjects);
+		DeclareAddress(Write);
+		DeclareAddress(Read);
+		DeclareAddress(GetCRC);
+		DeclareAddress(reset);
+		DeclareAddress(onSetSPSerializable);
+		DeclareAddress(onGetSPSerializable);
+		DeclareAddress(loadSingleObject);
+	}
+
+	class SerializerDatabase
+		: public ISerializerDatabase
+		, public Resource::Database
+		, public DefaultRefCounted
+	{
+	public:
+		SerializerDatabase(Resource::Database* pDatabase);
+
+		virtual ~SerializerDatabase();
+		virtual int AddRef() override;
+		virtual int Release() override;
+		virtual void* Cast(uint32_t type) const override;
+
+		virtual Resource::Database* AsDatabase() override;
+		virtual ICOMSerializer* GetCOMSerializer() override;
+		virtual bool OpenReadStream(const ResourceKey& key, ISerializerReadStream** ppStream) override;
+		virtual bool CloseReadStream(ISerializerReadStream* pStream) override;
+		virtual bool LoadClassObjects(uint32_t version) override;
+		virtual bool OpenWriteStream(const ResourceKey& key, ISerializerWriteStream** ppStream, bool bTruncate) override;
+		virtual bool CloseWriteStream(ISerializerWriteStream* pStream) override;
+		virtual bool SaveClassObjects() override;
+		virtual bool HasKey(const ResourceKey& key) const override;
+		virtual float GetPercentageCompletion() const override;
+		virtual void SetPercentageCompletion(float fPercentageCompletion0To100) override;
+
+		virtual bool Initialize() override;
+		virtual bool Dispose() override;
+		virtual uint32_t GetDatabaseType() const override;
+		virtual int GetRefCount() const override;
+		virtual void Lock(bool lock) override;
+		virtual bool Open(IO::AccessFlags desiredAccess = IO::AccessFlags::Read, IO::CD createDisposition = IO::CD::Default, bool bAutoOpen = false) override;
+		virtual bool Close() override;
+		virtual IO::AccessFlags GetAccessFlags() const override;
+		virtual bool Flush() override;
+		virtual const char16_t* GetLocation() const override;
+		virtual bool SetLocation(const char16_t* path) override;
+		virtual size_t GetKeyList(eastl::vector<ResourceKey>& dstVector, Resource::IKeyFilter* filter = nullptr) override;
+		virtual bool OpenRecord(
+			const ResourceKey& name,
+			Resource::IRecord** ppDst,
+			IO::AccessFlags desiredAccess = IO::AccessFlags::Read,
+			IO::CD createDisposition = IO::CD::Default,
+			bool arg_10 = true,
+			Resource::RecordInfo* pDstInfo = nullptr) override;
+		virtual int GetOpenCount(const ResourceKey& key) override;
+		virtual bool CloseRecord(Resource::IRecord* pRecord) override;
+		virtual bool DeleteRecord(const ResourceKey& name) override;
+		virtual bool Attach(bool, Resource::IResourceManager* pResourceMan, bool) override;
+		virtual ICoreAllocator* GetAllocator() const override;
+
+		virtual bool OpenAsSerializer(bool bOpenForReading, bool bOpenForWriting);
+	protected:
+		/* 18h */	eastl::intrusive_ptr<Resource::Database> mpDatabase;
+		/* 1Ch */	eastl::intrusive_ptr<ICOMSerializer> mpCOMSerializer;
+		/* 20h */	float mfPercentageCompletion0To100;
+	};
+	ASSERT_SIZE(SerializerDatabase, 0x24);
+
+	namespace Addresses(SerializerDatabase)
+	{
+		DeclareAddress(AsDatabase);
+		DeclareAddress(GetCOMSerializer);
+		DeclareAddress(OpenReadStream);
+		DeclareAddress(CloseReadStream);
+		DeclareAddress(LoadClassObjects);
+		DeclareAddress(OpenWriteStream);
+		DeclareAddress(CloseWriteStream);
+		DeclareAddress(SaveClassObjects);
+		DeclareAddress(HasKey);
+		DeclareAddress(GetPercentageCompletion);
+		DeclareAddress(SetPercentageCompletion);
+		DeclareAddress(Initialize);
+		DeclareAddress(Dispose);
+		DeclareAddress(GetDatabaseType);
+		DeclareAddress(GetRefCount);
+		DeclareAddress(Lock);
+		DeclareAddress(Open);
+		DeclareAddress(Close);
+		DeclareAddress(GetAccessFlags);
+		DeclareAddress(Flush);
+		DeclareAddress(GetLocation);
+		DeclareAddress(SetLocation);
+		DeclareAddress(GetKeyList);
+		DeclareAddress(OpenRecord);
+		DeclareAddress(GetOpenCount);
+		DeclareAddress(CloseRecord);
+		DeclareAddress(DeleteRecord);
+		DeclareAddress(Attach);
+		DeclareAddress(GetAllocator);
+		DeclareAddress(OpenAsSerializer);
 	}
 }
 


### PR DESCRIPTION
Add `COMSerializer`, `SerializerDatabase`, `SerializerReadStream`, `SerializerWriteStream`, `SerializerReadStreamPrivate`, `SerializerWriteStreamPrivate` to the `Simulator` namespace.