### PR TITLE
Add `GetThumbnail()` for `cScenarioAsset`

### DIFF
--- a/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
+++ b/Spore ModAPI/SourceCode/DLL/AddressesSimulator.cpp
@@ -53,6 +53,7 @@
 #include <Spore\Simulator\cSpaceInventoryItem.h>
 #include <Spore\Simulator\cSpaceNames.h>
 #include <Spore\Simulator\cStarRecord.h>
+#include <Spore\Simulator\cScenarioAsset.h>
 #include <Spore\Simulator\cScenarioData.h>
 #include <Spore\Simulator\cScenarioPlayMode.h>
 #include <Spore\Simulator\cScenarioResource.h>
@@ -900,6 +901,11 @@ namespace Simulator
 	namespace Addresses(cScenarioEditHistory)
 	{
 		DefineAddress(ptr, SelectAddress(0x160A850, 0x16065D8));
+	}
+
+	namespace Addresses(cScenarioAsset)
+	{
+		DefineAddress(GetThumbnail, SelectAddress(0xEF92F0, 0xF24FE0));
 	}
 
 	namespace Addresses(cScenarioData)

--- a/Spore ModAPI/SourceCode/Simulator/Scenario.cpp
+++ b/Spore ModAPI/SourceCode/Simulator/Scenario.cpp
@@ -8,6 +8,9 @@
 
 namespace Simulator
 {
+	auto_METHOD_VOID(cScenarioAsset, GetThumbnail, Args(ResourceKey& dst), Args(dst));
+
+
 	auto_METHOD_VOID(cScenarioData, Initialize, Args(bool index), Args(index));
 
 	auto_METHOD_VOID_(cScenarioData, StartHistoryEntry);

--- a/Spore ModAPI/Spore/App/Canvas.h
+++ b/Spore ModAPI/Spore/App/Canvas.h
@@ -54,29 +54,29 @@ namespace App
 		/* 9Ch */	virtual HMONITOR GetMonitor();
 
 	public:
-		/* 04h */	int field_4;  // 0xF
-		/* 08h */	int mOptions;  // 0x2A
-		/* 0Ch */	bool mIsFullscreen;
-		/* 0Dh */	bool field_D;
-		/* 0Eh */	bool field_E;
-		/* 0Fh */	bool field_F;
-		/* 10h */	bool field_10;
-		/* 11h */	bool field_11;
-		/* 14h */	int field_14;
-		/* 18h */	int field_18;
-		/* 1Ch */	bool field_1C;
-		/* 20h */	int field_20;
-		/* 24h */	eastl::string16 mCaption;
-		/* 34h */	int field_34;
-		/* 38h */	int field_38;
-		/* 3Ch */	tagRECT field_3C;
-		/* 4Ch */	bool field_4C;  // true
-		/* 4Dh */	bool field_4D;
-		/* 4Eh */	bool field_4E;
-		/* 4Fh */	bool field_4F;
-		/* 50h */	int field_50;  // 2000
-		/* 54h */	HKL mKeyboardLayout;
-		/* 58h */	int mDefaultAnsiCodeForLocale;
+		/* 04h */	uint32_t mnStyleFlags;  // 0xF
+		/* 08h */	uint32_t mnOptionFlags;  // 0x2A
+		/* 0Ch */	bool mbFullscreen;
+		/* 0Dh */	bool mbBlockInput;
+		/* 0Eh */	bool mbInMovingSizeLoop;
+		/* 0Fh */	bool mbInSizingLoop;
+		/* 10h */	bool mbInMovingLoop;
+		/* 11h */	bool mbMouseInClientArea;
+		/* 14h */	int mnLastMouseX;
+		/* 18h */	int mnLastMouseY;
+		/* 1Ch */	bool mbEnablePaint;
+		/* 20h */	uint32_t mnUpdateLockCount;
+		/* 24h */	eastl::string16 msCaption;
+		/* 34h */	uint32_t mnMinWidth;
+		/* 38h */	uint32_t mnMinHeight;
+		/* 3Ch */	tagRECT mRectDesiredClient;
+		/* 4Ch */	bool mbCursorVisible;  // true
+		/* 4Dh */	bool mbCursorShadowSupported;
+		/* 4Eh */	bool mbMouseTrailsSupported;
+		/* 4Fh */	bool mbMouseSonarSupported;
+		/* 50h */	uint32_t mnIdleTimerIntervalMs;  // 2000
+		/* 54h */	HKL mnKeyboardLayout;
+		/* 58h */	int mnDefaultAnsiCodeForLocale;
 		/* 5Ch */	IMessageManager* mpMessageServer;
 		/* 60h */	int field_60;
 		/* 64h */	int field_64;

--- a/Spore ModAPI/Spore/App/IDGenerator.h
+++ b/Spore ModAPI/Spore/App/IDGenerator.h
@@ -35,7 +35,7 @@ namespace App
 		/* 08h */	virtual void GenerateForGroup(ResourceKey& dst, uint32_t typeID, uint32_t groupID);
 
 	public:
-		/* 04h */	int field_4;  // time?
+		/* 04h */	uint32_t mnStartInstance;
 		/* 08h */	eastl::map<int, int> field_8;
 		/* 28h */	eastl::map<int, int> field_24;
 	};

--- a/Spore ModAPI/Spore/Simulator/cScenarioAsset.h
+++ b/Spore ModAPI/Spore/Simulator/cScenarioAsset.h
@@ -40,6 +40,6 @@ namespace Simulator
 
 	namespace Addresses(cScenarioAsset)
 	{
-		DefineAddress(GetThumbnail);
+		DeclareAddress(GetThumbnail);
 	}
 }

--- a/Spore ModAPI/Spore/Simulator/cScenarioAsset.h
+++ b/Spore ModAPI/Spore/Simulator/cScenarioAsset.h
@@ -25,6 +25,11 @@ namespace Simulator
 	class cScenarioAsset
 	{
 	public:
+
+		/// Gets the ResourceKey of an asset thumbnail to display in the editor palette.
+		/// @param[out] dst The destination value that will be assigned with the ResourceKey of a thumbnail.
+		void GetThumbnail(ResourceKey& dst);
+
 		/* 00h */	ResourceKey mKey;
 		/* 0Ch */	uint32_t mMachineId;
 		/* 10h */	uint64_t mServerId;
@@ -32,4 +37,9 @@ namespace Simulator
 		/* 1Ch */	bool field_1C;
 	};
 	ASSERT_SIZE(cScenarioAsset, 0x20);
+
+	namespace Addresses(cScenarioAsset)
+	{
+		DefineAddress(GetThumbnail);
+	}
 }


### PR DESCRIPTION
`GetThumbnail()` is used to determine the original (not skinned) thumbnail of `cScenarioClass` and may also be a function of it instead (as `cScenarioAsset mAsset` is the first field there), but having it as a member of `cScenarioAsset` is more useful in my opinion.