### PR TITLE
Terrain-related improvements: add `cTerrainSphereDecal` and rename many fields in different classes

### DIFF
--- a/Spore ModAPI/SourceCode/DLL/AddressesTerrain.cpp
+++ b/Spore ModAPI/SourceCode/DLL/AddressesTerrain.cpp
@@ -69,6 +69,15 @@ namespace Terrain
 		DefineAddress(ApplyTerrainUserBeachColor, SelectAddress(0xFBDDD0, 0xFBD6B0));
 		DefineAddress(ApplyTerrainUserAtmosphereColor, SelectAddress(0xFB98C0, 0xFB91A0));
 	}
+
+	namespace Addresses(cTerrainSphereDecal) {
+		DefineAddress(Initialize, SelectAddress(0xF82DD0, 0xFAEC20));
+		DefineAddress(Shutdown, SelectAddress(0xF81C20, 0xFADA70));
+		DefineAddress(UpdateDecal, SelectAddress(0xF82960, 0xFAE7B0));
+		DefineAddress(DispatchStaticDecal, SelectAddress(0xF816B0, 0xFAD500));
+		DefineAddress(GetBBoxForFace, SelectAddress(0xF812A0, 0xFAD0F0));
+		DefineAddress(SetFaceInfoArray, SelectAddress(0xF81D80, 0xFADBD0));
+	}
 }
 namespace Addresses(Terrain)
 {

--- a/Spore ModAPI/SourceCode/Terrain/Terrain.cpp
+++ b/Spore ModAPI/SourceCode/Terrain/Terrain.cpp
@@ -4,6 +4,7 @@
 #include <Spore\Terrain\cTerrainMapSet.h>
 #include <Spore\Terrain\cTerrainStateMgr.h>
 #include <Spore\Terrain\cTerrainSphere.h>
+#include <Spore\Terrain\cTerrainSphereDecal.h>
 #include <Spore\Terrain\TerrainRendering.h>
 #include <Spore\Graphics\ITextureManager.h>
 #include <Spore\Properties.h>
@@ -57,13 +58,9 @@ namespace Terrain
 
 
 	cTerrainMapSet::cHeightRanges::cHeightRanges()
-		: field_0(0x55)
-		, field_4(1)
-		, field_8(5)
-		, field_C(0x15)
-		, field_10(0x55)
-		, field_14(0x155)
-		, mpCell(new int[8190])
+		: mFaceSize(0x55)
+		, mLevelOffsets{ 1, 5, 0x15, 0x55, 0x155 }
+		, mCellData(new int[8190])
 	{
 
 	}
@@ -74,12 +71,11 @@ namespace Terrain
 		, mPlanetRadius(500.0f)
 		, mAltitudeRange(100.0f)
 		, mWaterLevel()
-		, field_40()
-		, field_44(0.025f)
-		, field_48()
+		, mWaterDelta()
+		, mBeachLevel(0.025f)
+		, mMinCliffGradient()
 		, mMaxCliffGradient()
-		, field_50(-1.0f)
-		, field_54(-1.0f)
+		, mHeightRange(-1.0f, -1.0f)
 		, mpHeightRanges(new cHeightRanges())
 	{
 
@@ -88,7 +84,7 @@ namespace Terrain
 	cTerrainMapSet::~cTerrainMapSet()
 	{
 		if (mpHeightRanges) {
-			if (mpHeightRanges->mpCell) delete mpHeightRanges->mpCell;
+			if (mpHeightRanges->mCellData) delete mpHeightRanges->mCellData;
 			delete mpHeightRanges;
 		}
 	}
@@ -331,6 +327,30 @@ namespace Terrain
 	}
 
 
+	cTerrainSphereDecal::cTerrainSphereDecal()
+		: field_74(-1)
+		, mpParentSphere(nullptr)
+		, mpTerrainMapSet(nullptr)
+		, mFaceArray()
+		, mPosition()
+		, mUSize(0)
+		, mVSize(0)
+		, mUSizeInput(0)
+		, mVSizeInput(0)
+		, mDecalRadius(1.0f)
+		, mDecalTextureID(0)
+		, mFlags(0)
+		, mZeroUVLoc(0, 0, 0)
+		, mTexturePlane(0, 0, 0, 0)
+		, mDirectionU(1.0f, 0, 0)
+		, mScaleU(1.0f)
+		, mDirectionV(0, 1.0f, 0)
+		, mScaleV(1.0f)
+		, mpTexture(nullptr)
+	{
+
+	}
+
 	auto_METHOD_VOID(cTerrainStateMgr, Initialize, Args(bool a), Args(a));
 
 	auto_METHOD_VOID_(cTerrainStateMgr, InitTextures);
@@ -344,6 +364,15 @@ namespace Terrain
 	auto_METHOD_VOID(cTerrainStateMgr, ApplyTerrainUserCliffColor, Args(struct Math::Vector3 color), Args(color));
 	auto_METHOD_VOID(cTerrainStateMgr, ApplyTerrainUserBeachColor, Args(struct Math::Vector3 color), Args(color));
 	auto_METHOD_VOID(cTerrainStateMgr, ApplyTerrainUserAtmosphereColor, Args(struct Math::Vector3 color), Args(color));
+
+
+	auto_METHOD_VOID(cTerrainSphereDecal, Initialize, Args(int arg_4, Graphics::Texture* pTexture, cTerrainSphere* pParentSphere, const Transform& xform, float turns, bool isStatic), Args(arg_4, pTexture, pParentSphere, xform, turns, isStatic));
+	auto_METHOD_VOID_(cTerrainSphereDecal, Shutdown);
+	auto_METHOD_VOID_(cTerrainSphereDecal, UpdateDecal);
+	auto_METHOD_VOID(cTerrainSphereDecal, DispatchStaticDecal, Args(int face), Args(face));
+	auto_METHOD(cTerrainSphereDecal, bool, GetBBoxForFace, Args(int faceRequest, Math::Rectangle& bbox), Args(faceRequest, bbox));
+
+	auto_METHOD_VOID(cTerrainSphereDecal, SetFaceInfoArray, Args(const Transform& xform, float aspect), Args(xform, aspect));
 }
 
 

--- a/Spore ModAPI/Spore ModAPI.vcxproj
+++ b/Spore ModAPI/Spore ModAPI.vcxproj
@@ -330,8 +330,12 @@
     <ClInclude Include="Spore\Editors\cSPEditorVerbTrayCollection.h" />
     <ClInclude Include="Spore\Editors\cSPEditorVerbIcon.h" />
     <ClInclude Include="Spore\Editors\cSPEditorVerbIconTray.h" />
+    <ClInclude Include="Spore\Graphics\cCubeMapCoord.h" />
     <ClInclude Include="Spore\IO\IniFile.h" />
     <ClInclude Include="Spore\IO\StreamCompressionZLib.h" />
+    <ClInclude Include="Spore\Swarm\cDecal.h" />
+    <ClInclude Include="Spore\Terrain\cTerrainDecal.h" />
+    <ClInclude Include="Spore\Terrain\cTerrainSphereDecal.h" />
     <ClInclude Include="Spore\UI\cSPUIPropertyLayout.h" />
     <ClInclude Include="Spore\Editors\cSPVerbIconRollover.h" />
     <ClInclude Include="Spore\Editors\cSPVerbTrayCollection.h" />

--- a/Spore ModAPI/Spore ModAPI.vcxproj.filters
+++ b/Spore ModAPI/Spore ModAPI.vcxproj.filters
@@ -2292,6 +2292,18 @@
     <ClInclude Include="Spore\IO\IniFile.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Spore\Swarm\cDecal.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Spore\Terrain\cTerrainDecal.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Spore\Terrain\cTerrainSphereDecal.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Spore\Graphics\cCubeMapCoord.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="SourceCode\Allocator.cpp">

--- a/Spore ModAPI/Spore/App/cJob.h
+++ b/Spore ModAPI/Spore/App/cJob.h
@@ -12,6 +12,20 @@ namespace App
 	typedef bool(*cJobCallback)(cJob*, void*);
 	typedef void(*cJobVoidCallback)(cJob*, void*);
 
+	enum JobStatus
+	{
+		kJobStatusFree,
+		kJobStatusSuspended,
+		kJobStatusWaiting,
+		kJobStatusReady,
+		kJobStatusRunning,
+		kJobStatusContinuation,
+		kJobStatusCancelled,
+		kJobStatusFinished,
+		kJobStatusFailed,
+		kJobStatusCount
+	};
+
 	class cJob
 	{
 	public:
@@ -51,8 +65,12 @@ namespace App
 		/* 00h */	cJobCallback mCallback;
 		/* 04h */	void* mpCallbackObject;
 		/* 08h */	ObjectPtr mReleasebleObject;
-		/* 0Ch */	char padding[0x18 - 0xC];
+		/* 0Ch */	char* mpDebugName;
+		/* 10h */	int mPriority;
+		/* 14h */	JobStatus mStatus;
 		/* 18h */	uint32_t mThreadAffinity;
+		/* 1Ch */	int mSlot;
+		/* 20h */	void* mpReturnValue;
 	};
 
 	namespace Addresses(cJob)

--- a/Spore ModAPI/Spore/Graphics/ShaderData.h
+++ b/Spore ModAPI/Spore/Graphics/ShaderData.h
@@ -41,4 +41,11 @@ namespace Graphics
 		Math::Vector4 mShadowDir;
 		Math::Vector4 mNestInfo;
 	};
+
+	struct ShaderDataDecalState
+	{
+		Math::Vector4 mDecalColorTint;
+		Math::Vector4 mDirScaleU;
+		Math::Vector4 mDirScaleV;
+	};
 }

--- a/Spore ModAPI/Spore/Graphics/cCubeMapCoord.h
+++ b/Spore ModAPI/Spore/Graphics/cCubeMapCoord.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <Spore\Internal.h>
+
+namespace Graphics
+{
+	struct cCubeMapCoord
+	{
+		/* 00h */	float mU;
+		/* 04h */	float mV;
+		/* 08h */	int mFace;
+	};
+	ASSERT_SIZE(cCubeMapCoord, 0x0C);
+}

--- a/Spore ModAPI/Spore/Graphics/cMeshData.h
+++ b/Spore ModAPI/Spore/Graphics/cMeshData.h
@@ -16,7 +16,7 @@ namespace Graphics
 		/* 08h */	eastl::vector<int> mElementsArray;  // cMDElementArray
 		/* 1Ch */	eastl::vector<int> mSections;  // cMDSection
 		/* 30h */	eastl::vector<int> mPrimitives;  // cMDPrimitive
-		/* 44h */	eastl::vector<int> field_44;  // ObjectPtr
+		/* 44h */	eastl::vector<ObjectPtr> mAttachments;
 	};
 	ASSERT_SIZE(cMeshData, 0x58);
 }

--- a/Spore ModAPI/Spore/Palettes/cSPScenarioBrushItemUI.h
+++ b/Spore ModAPI/Spore/Palettes/cSPScenarioBrushItemUI.h
@@ -18,8 +18,8 @@ namespace Palettes
 		/* 3Ch */	ResourceKey mToolPreviewEffect;
 		/* 48h */	ResourceKey mMarkerModelID;
 		/* 54h */	uint32_t mBrushCategory;
-		/* 58h */	Vector2 mBrushIntensityRange;  // 0.0, 1.0
-		/* 60h */	Vector2 mBrushSizeRange;  // 0.0, 1.0
+		/* 58h */	Math::Vector2 mBrushIntensityRange;  // 0.0, 1.0
+		/* 60h */	Math::Vector2 mBrushSizeRange;  // 0.0, 1.0
 		/* 68h */	bool mIsTerraformModel;  // uses terraformModelID instead of toolGenericEffectID
 		/* 69h */	bool mIsValidComplexity;  // true
 		/* 6Ah */	bool mIsDragging;

--- a/Spore ModAPI/Spore/Resource/FakeRecord.h
+++ b/Spore ModAPI/Spore/Resource/FakeRecord.h
@@ -26,7 +26,7 @@ namespace Resource
 		/* 10h */	ResourceKey mKey;
 		/* 1Ch */	bool mCloseStreamOnClose;
 		/* 1Dh */	bool mDeleteStreamOnClose;
-		/* 20h */	int field_20;
+		/* 20h */	int mnOpenCount; // AtomicInt<int>
 	};
 	ASSERT_SIZE(FakeRecord, 0x24);
 

--- a/Spore ModAPI/Spore/Simulator/ICityMusic.h
+++ b/Spore ModAPI/Spore/Simulator/ICityMusic.h
@@ -12,10 +12,10 @@ namespace Simulator
 	{
 		static const uint32_t TYPE = 0x424E7F2;
 
-		/* 24h */	virtual void func24h(const Math::Vector3&) = 0;
-		/* 28h */	virtual void func28h() = 0;
-		/* 2Ch */	virtual void func2Ch(bool) = 0;
-		/* 30h */	virtual void func30h(const Math::Vector3&) = 0;
+		/* 24h */	virtual void Start(const Math::Vector3&) = 0;
+		/* 28h */	virtual void Stop() = 0;
+		/* 2Ch */	virtual void Pause(bool) = 0;
+		/* 30h */	virtual void SetPosition(const Math::Vector3&) = 0;
 		/* 34h */	virtual int func34h() = 0;
 	};
 }

--- a/Spore ModAPI/Spore/Simulator/cPlanet.h
+++ b/Spore ModAPI/Spore/Simulator/cPlanet.h
@@ -91,7 +91,7 @@ namespace Simulator
 		/* 184h */	float mPlanetScale;
 		/* 188h */	cSolarHitSpherePtr mpSolarHitSphere;
 		/* 18Ch */	cVisiblePlanetPtr mpVisiblePlanet;
-		/* 190h */	bool field_190;  // true
+		/* 190h */	bool mbLoadNounsFromBackground;  // true
 		/* 198h */	cGonzagoTimer mTimeSinceLastColonyPlaced;
 		/* 1B8h */	bool field_1B8;  // true
 		/* 1BCh */	int mPlanetFlags;

--- a/Spore ModAPI/Spore/Simulator/cPlanetRecord.h
+++ b/Spore ModAPI/Spore/Simulator/cPlanetRecord.h
@@ -82,7 +82,7 @@ namespace Simulator
 		/* 3Ch */	float mCapturePercent;
 		/* 40h */	eastl::string16 mName;
 		/* 50h */	eastl::string16 mDescription;
-		/* 60h */	int16_t field_60[14];
+		/* 60h */	uint16_t maabBuildingLinks[14];
 		/* 7Ch */	eastl::vector<cBuildingData> mBuilding;
 		/* 90h */	eastl::vector<cOrnamentData> mOrnament;
 		/* A4h */	eastl::vector<cWallData> mWall;

--- a/Spore ModAPI/Spore/Swarm/cDecal.h
+++ b/Spore ModAPI/Spore/Swarm/cDecal.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <Spore\Transform.h>
+#include <EASTL\bitset.h>
+
+namespace Swarm
+{
+	enum DecalType
+	{
+		kDecalTypeTerrain,
+		kDecalTypeWater,
+		kDecalTypeTerrainAndWater,
+		kDecalTypePaint,
+		kDecalTypeUser1,
+		kDecalTypeUser2,
+		kDecalTypeUser3,
+		kDecalTypeUser4,
+		kDecalTypeUser5,
+		kDecalTypeUser6,
+		kDecalTypeUser7,
+		kDecalTypeUser8,
+
+		kMaxDecalTypes
+	};
+
+	class cDecal
+	{
+	public:
+		typedef eastl::bitset<1> FlagSet;
+
+		enum Flags
+		{
+			kFlagEnabled,
+
+			kMaxFlags
+		};
+
+		/* 00h */	Transform mTransform;
+		/* 38h */	Math::Vector4 mColorAlpha{ 1.0f, 1.0f, 1.0f, 1.0f };
+		/* 48h */	float mTurns = 1.0f;
+		/* 4Ch */	float mAspect = 1.0f;
+		/* 50h */	float mRepeatU = 1.0f;
+		/* 54h */	float mRepeatV = 1.0f;
+		/* 58h */	float mOffsetU = 1.0f;
+		/* 5Ch */	float mOffsetV = 1.0f;
+		/* 60h */	uint32_t mLayer = 0;
+		/* 64h */	FlagSet mFlags = 0;
+	};
+	ASSERT_SIZE(cDecal, 0x68);
+}

--- a/Spore ModAPI/Spore/Terrain.h
+++ b/Spore ModAPI/Spore/Terrain.h
@@ -17,3 +17,4 @@
 #include <Spore\Terrain\ITerrainResourceManager.h>
 #include <Spore\Terrain\cTerrainMapSet.h>
 #include <Spore\Terrain\cTerrainShaderMgr.h>
+#include <Spore\Terrain\cTerrainSphereDecal.h>

--- a/Spore ModAPI/Spore/Terrain/cTerrainDecal.h
+++ b/Spore ModAPI/Spore/Terrain/cTerrainDecal.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <Spore\Swarm\cDecal.h>
+
+namespace Terrain
+{
+	struct cTerrainDecal
+		: public Swarm::cDecal
+	{
+		/* 68h */	Swarm::DecalType mType = Swarm::DecalType::kDecalTypeTerrain;
+	};
+	ASSERT_SIZE(cTerrainDecal, 0x6C);
+}

--- a/Spore ModAPI/Spore/Terrain/cTerrainMapSet.h
+++ b/Spore ModAPI/Spore/Terrain/cTerrainMapSet.h
@@ -47,14 +47,11 @@ namespace Terrain
 		{
 			cHeightRanges();
 
-			/* 00h */	int field_0;  // 0x555
-			/* 04h */	int field_4;  // 1
-			/* 08h */	int field_8;  // 5
-			/* 0Ch */	int field_C;  // 0x15
-			/* 10h */	int field_10;  // 0x55
-			/* 14h */	int field_14;  // 0x155
-			/* 18h */	int* mpCell;
+			/* 00h */	int mFaceSize;  // 0x555
+			/* 04h */	int mLevelOffsets[5];  // 1, 5, 0x15, 0x55, 0x155
+			/* 18h */	int* mCellData;
 		};
+		ASSERT_SIZE(cHeightRanges, 0x1C);
 
 		cTerrainMapSet();
 		virtual ~cTerrainMapSet();
@@ -82,12 +79,11 @@ namespace Terrain
 		/* 38h */	float mAltitudeRange;  // 100.0
 		/// Between -1 and 1, gets multiplied by altitude range
 		/* 3Ch */	float mWaterLevel;
-		/* 40h */	float field_40;
-		/* 44h */	float field_44;  // 0.025
-		/* 48h */	float field_48;
+		/* 40h */	float mWaterDelta;
+		/* 44h */	float mBeachLevel;  // 0.025
+		/* 48h */	float mMinCliffGradient;
 		/* 4Ch */	float mMaxCliffGradient;
-		/* 50h */	float field_50;  // -1.0
-		/* 54h */	float field_54;  // -1.0
+		/* 50h */	Math::Vector2 mHeightRange;
 		/* 58h */	cHeightRanges* mpHeightRanges;
 	};
 	ASSERT_SIZE(cTerrainMapSet, 0x5C);

--- a/Spore ModAPI/Spore/Terrain/cTerrainSphere.h
+++ b/Spore ModAPI/Spore/Terrain/cTerrainSphere.h
@@ -36,14 +36,35 @@
 
 namespace Terrain
 {
+	enum TerrainGameMode
+	{
+		kTerrainGameModeCreature,
+		kTerrainGameModeTribe,
+		kTerrainGameModeCiv,
+		kTerrainGameModeSpace,
+		kTerrainGameModeOther,
+
+		kMaxTerrainGameModes
+	};
+
 	struct cTerrainSphereRenderingChunk
 	{
 		/* 00h */	cTerrainSphereQuad* mpQuad;
-		/* 04h */	float field_4;
-		/* 08h */	int mFlags;  // 0x40: don't render
+		/* 04h */	float mMorphValue;
+		/* 08h */	uint32_t mFlags;  // 0x40: don't render
 		/* 0Ch */	int field_C;  // always 0?
 	};
 	ASSERT_SIZE(cTerrainSphereRenderingChunk, 0x10);
+
+	struct cTerrainSphereLight
+	{
+		/* 00h */	uint32_t mID;
+		/* 04h */	Vector3 mPosition;
+		/* 10h */	Vector3 mColor;
+		/* 1Ch */	float mRadius;
+		/* 20h */	bool mDirty;
+	};
+	ASSERT_SIZE(cTerrainSphereLight, 0x24);
 
 	class cTerrainSphere
 		: public ITerrain
@@ -128,9 +149,9 @@ namespace Terrain
 		/* 24h */	int field_24;
 		/* 28h */	PropertyListPtr mpPropList;
 		/* 2Ch */	cTerrainMapSetPtr mpTerrainMapSet;
-		/* 30h */	TextureContainer field_30;
-		/* 74h */	TextureContainer field_74;
-		/* B8h */	TextureContainer field_B8;
+		/* 30h */	TextureContainer mpLoaderTerrainBackground;
+		/* 74h */	TextureContainer mpLoaderTerrainForeground;
+		/* B8h */	TextureContainer mLoaderImpostor;
 		/* FCh */	TextureContainer* mpLoader;
 		/* 100h */	ITerrain::OnLoadFinish_t mOnLoadFinish;
 		/* 104h */	void* mOnLoadFinishObject;
@@ -146,10 +167,10 @@ namespace Terrain
 		/* 178h */	TexturePtr mTerrainControlMaps[6];
 		/// The terrain land quads that have to be rendered
 		/* 190h	*/	eastl::vector<cTerrainSphereRenderingChunk> mLandRenderingChunks;
-		/* 1A4h */	eastl::vector<int> field_1A4;
-		/* 1B8h */	eastl::vector<int> field_1B8;
+		/* 1A4h */	eastl::vector<cTerrainSphereRenderingChunk> mSeabedRenderingChunks;
+		/* 1B8h */	eastl::vector<cTerrainSphereRenderingChunk> mAtmosphereRenderingChunks;
 		/* 1CCh */	uint32_t mSeed;
-		/* 1D0h */	int field_1D0;  // 4
+		/* 1D0h */	TerrainGameMode mGameMode;
 		/* 1D4h */	int mPlanetLODChunkRes;  // 16
 		/* 1D8h */	float mPlanetUnderwaterCullRadius;  // 25.0
 		/* 1DCh */	float mPlanetUnderwaterLargeCullRadius;  // 100.0
@@ -167,19 +188,13 @@ namespace Terrain
 		/* 20Ch */	cTerrainStateMgr* mpTerrainStateMgr;
 		/* 210h */	cWeatherManagerPtr mpWeatherManager;
 		/* 214h */	int field_214;
-		/* 218h */	eastl::vector<int> field_218;
-		/* 22Ch */	eastl::vector<int> field_22C;
-		/* 240h */	eastl::vector<int> field_240;
-		/* 254h */	eastl::vector<int> field_254;
-		/* 268h */	eastl::vector<int> field_268;
-		/* 27Ch */	eastl::vector<int> field_27C;
-		/* 290h */	eastl::vector<int> field_290;
-		/* 2A4h */	eastl::vector<int> field_2A4;
-		/* 2B8h */	eastl::vector<int> field_2B8;
-		/* 2CCh */	eastl::vector<int> field_2CC;
-		/* 2E0h */	eastl::vector<int> field_2E0;
-		/* 2F4h */	eastl::vector<int> field_2F4;
-		/* 308h */	TexturePtr field_308;  // PLACEHOLDER 0xE5230445
+		/* 218h */	eastl::vector<int> mpDecalList[4];
+		/* 268h */	eastl::vector<int> mDecalIdFreeList[4];
+		/* 2B8h */	eastl::vector<int> mpDecalSegList;
+		/* 2CCh */	eastl::vector<int> mDecalSegListIdFreeList;
+		/* 2E0h */	eastl::vector<int> mLightingRegions;
+		/* 2F4h */	eastl::vector<cTerrainSphereLight*> mLights;
+		/* 308h */	TexturePtr mpLightTexture;  // PLACEHOLDER 0xE5230445
 		/* 30Ch */	Math::Vector4 mCameraPos;
 		/* 31Ch */	Math::Vector4 mCameraDir;
 		/* 32Ch */	Math::Vector4 mSunDir;
@@ -220,10 +235,10 @@ namespace Terrain
 		/* 7D8h */	eastl::vector<ModelPtr> mModels;
 		/* 7ECh */	eastl::vector<IVisualEffectPtr> mAmbientEffects;
 		/* 800h */	eastl::vector<IVisualEffectPtr> mAmbientSoundEffects;
-		/* 814h */	int mPlayerModCount;
+		/* 814h */	uint32_t mPlayerModCount;
 		/* 818h */	int field_818;
-		/* 81Ch */	int field_81C;
-		/* 820h */	char padding_820[0x60];
+		/* 81Ch */	cJobPtr mBackgroundJob;
+		/* 820h */	char mBackgroundUpdateBBox[0x60];
 		/* 880h */	bool field_880;
 		/* 884h */	int field_884;
 		/* 888h */	int field_888;
@@ -233,8 +248,8 @@ namespace Terrain
 		/* 898h */	int field_898;  // -1
 		/* 89Ch */	int field_89C;  // -1
 		/* 8A0h */  void* mpImpostorJob;  //PLACEHOLDER cTerrainSphereImpostorJob
-		/* 8A4h */	int field_8A4;  // -1
-		/* 8A8h */	int field_8A8;
+		/* 8A4h */	uint32_t mImpostorJobId;  // -1
+		/* 8A8h */	uint32_t mImpostorMessageId;
 		/* 8ACh */	bool mAllowUnderwaterObjects;
 		// int are flags for renderable
 		/* 8B0h */	eastl::vector<eastl::pair<IModelWorldPtr, int>> mUnderwaterModelWorlds;

--- a/Spore ModAPI/Spore/Terrain/cTerrainSphereDecal.h
+++ b/Spore ModAPI/Spore/Terrain/cTerrainSphereDecal.h
@@ -4,6 +4,9 @@
 #include <Spore\Graphics\cCubeMapCoord.h>
 #include <Spore\Graphics\ShaderData.h>
 #include <Spore\Terrain\cTerrainDecal.h>
+#include <EASTL\vector.h>
+#include <Spore\Graphics\Texture.h>
+#include <Spore\MathUtils.h>
 
 namespace Terrain
 {
@@ -109,11 +112,11 @@ namespace Terrain
 		/* B4h */	int mDecalTextureID;
 		/* B8h */	uint32_t mFlags;
 		/* BCh */	Graphics::ShaderDataDecalState mShaderDataDecalState;
-		/* ECh */	Vector3 mZeroUVLoc;
-		/* F8h */	Vector4 mTexturePlane;
-		/* 108h */	Vector3 mDirectionU;
+		/* ECh */	Math::Vector3 mZeroUVLoc;
+		/* F8h */	Math::Vector4 mTexturePlane;
+		/* 108h */	Math::Vector3 mDirectionU;
 		/* 114h */	float mScaleU;
-		/* 118h */	Vector3 mDirectionV;
+		/* 118h */	Math::Vector3 mDirectionV;
 		/* 124h */	float mScaleV;
 		/* 128h */	TexturePtr mpTexture;
 	};

--- a/Spore ModAPI/Spore/Terrain/cTerrainSphereDecal.h
+++ b/Spore ModAPI/Spore/Terrain/cTerrainSphereDecal.h
@@ -4,11 +4,12 @@
 #include <Spore\Graphics\cCubeMapCoord.h>
 #include <Spore\Graphics\ShaderData.h>
 #include <Spore\Terrain\cTerrainDecal.h>
-#include <Spore\Terrain\cTerrainSphere.h>
-#include <Spore\Terrain\cTerrainMapSet.h>
 
 namespace Terrain
 {
+	class cTerrainSphere;
+	class cTerrainMapSet;
+
 	class cTerrainSphereDecal
 		: public DefaultRefCounted
 		, public cTerrainDecal

--- a/Spore ModAPI/Spore/Terrain/cTerrainSphereDecal.h
+++ b/Spore ModAPI/Spore/Terrain/cTerrainSphereDecal.h
@@ -1,0 +1,130 @@
+#pragma once
+
+#include <Spore\Object.h>
+#include <Spore\Graphics\cCubeMapCoord.h>
+#include <Spore\Graphics\ShaderData.h>
+#include <Spore\Terrain\cTerrainDecal.h>
+#include <Spore\Terrain\cTerrainSphere.h>
+#include <Spore\Terrain\cTerrainMapSet.h>
+
+namespace Terrain
+{
+	class cTerrainSphereDecal
+		: public DefaultRefCounted
+		, public cTerrainDecal
+	{
+		enum : uint32_t
+		{
+			kEnabled = 1,
+			kBelowWater = 2,
+			kEmissive = 4,
+			kUseFog = 8,
+			kStatic = 16
+		};
+
+	public:
+		struct FaceInfo
+		{
+			/* 00h */	uint32_t mFace;
+			/* 04h */	Math::Rectangle mBoundingBoxFace;
+		};
+		ASSERT_SIZE(FaceInfo, 0x14);
+
+		cTerrainSphereDecal();
+
+		void Initialize(int arg_4, Graphics::Texture* pTexture, cTerrainSphere* pParentSphere, const Transform& xform, float turns, bool isStatic);
+		void Shutdown();
+		void UpdateDecal();
+		void DispatchStaticDecal(int face);
+		bool GetBBoxForFace(int faceRequest, Math::Rectangle& bbox);
+
+
+		inline bool IsInitialized()
+		{
+			return mpTerrainMapSet != nullptr;
+		}
+		inline Math::Rectangle* GetBoundingBox(int face)
+		{
+			return &mFaceArray[face].mBoundingBoxFace;
+		}
+		inline void SetTexture(Graphics::Texture* pTexture)
+		{
+			mpTexture = pTexture;
+		}
+		inline Graphics::Texture* GetTexture() const
+		{
+			return mpTexture.get();
+		}
+		inline bool IsBelowWater() const
+		{
+			return GetFlag(kBelowWater);
+		}
+		inline void SetDecalEmissive(bool val)
+		{
+			SetFlag(kEmissive, val);
+		}
+		inline bool GetDecalEmissive() const
+		{
+			return GetFlag(kEmissive);
+		}
+		inline void SetDecalFog(bool val)
+		{
+			SetFlag(kUseFog, val);
+		}
+		inline bool GetDecalFog() const
+		{
+			return GetFlag(kUseFog);
+		}
+		inline bool GetDecalIsStatic() const
+		{
+			return GetFlag(kStatic);
+		}
+	private:
+		void SetFaceInfoArray(const Transform& xform, float aspect);
+
+		inline bool GetFlag(uint32_t flag) const
+		{
+			return mFlags & flag;
+		}
+		inline void SetFlag(uint32_t flag, bool set)
+		{
+			if (set)
+				mFlags |= flag;
+			else
+				mFlags &= ~flag;
+		}
+
+	public:
+		/* 74h */	int field_74; // -1
+		/* 78h */	cTerrainSphere* mpParentSphere;
+		/* 7Ch */	cTerrainMapSet* mpTerrainMapSet;
+		/* 80h */	eastl::vector<FaceInfo> mFaceArray;
+		/* 94h */	Graphics::cCubeMapCoord mPosition;
+		/* A0h */	float mUSize;
+		/* A4h */	float mVSize;
+		/* A8h */	float mUSizeInput;
+		/* ACh */	float mVSizeInput;
+		/* B0h */	float mDecalRadius;
+		/* B4h */	int mDecalTextureID;
+		/* B8h */	uint32_t mFlags;
+		/* BCh */	Graphics::ShaderDataDecalState mShaderDataDecalState;
+		/* ECh */	Vector3 mZeroUVLoc;
+		/* F8h */	Vector4 mTexturePlane;
+		/* 108h */	Vector3 mDirectionU;
+		/* 114h */	float mScaleU;
+		/* 118h */	Vector3 mDirectionV;
+		/* 124h */	float mScaleV;
+		/* 128h */	TexturePtr mpTexture;
+	};
+	ASSERT_SIZE(cTerrainSphereDecal, 0x12C);
+
+	namespace Addresses(cTerrainSphereDecal)
+	{
+		DeclareAddress(Initialize);
+		DeclareAddress(Shutdown);
+		DeclareAddress(UpdateDecal);
+		DeclareAddress(DispatchStaticDecal);
+		DeclareAddress(GetBBoxForFace);
+		DeclareAddress(SetFaceInfoArray);
+	}
+}

--- a/Spore ModAPI/Spore/Terrain/cTerrainSphereQuad.h
+++ b/Spore ModAPI/Spore/Terrain/cTerrainSphereQuad.h
@@ -23,13 +23,13 @@
 #include <Spore\RenderWare\IndexBuffer.h>
 #include <Spore\Graphics\ILayer.h>
 #include <Spore\Terrain\cTerrainShaderMgr.h>
+#include <Spore\Terrain\cTerrainSphereDecal.h>
 #include <Spore\MathUtils.h>
 #include <EASTL\vector.h>
 
 namespace Terrain
 {
 	class cTerrainSphere;
-	class cTerrainSphereDecal;
 
 	struct TerrainTransform
 	{

--- a/Spore ModAPI/Spore/Terrain/cTerrainSphereQuad.h
+++ b/Spore ModAPI/Spore/Terrain/cTerrainSphereQuad.h
@@ -29,6 +29,7 @@
 namespace Terrain
 {
 	class cTerrainSphere;
+	class cTerrainSphereDecal;
 
 	struct TerrainTransform
 	{
@@ -47,6 +48,15 @@ namespace Terrain
 		/* 04h */	RenderWare::IndexBuffer* indexBuffer;
 		// anything else?
 	};
+
+	struct cTerrainSphereQuadDecal
+	{
+		/* 00h */	cTerrainSphereDecal* mpDecal;
+		/* 04h */	void* mpIndexBuffer; // IndexBuffer
+		/* 08h */	int field_8;
+		/* 0Ch */	int field_C;
+	};
+	ASSERT_SIZE(cTerrainSphereQuadDecal, 0x10);
 
 	class cTerrainSphereQuad
 	{
@@ -108,26 +118,23 @@ namespace Terrain
 
 	public:
 		/* 00h */	cTerrainSphere* mpSphere;
-		/* 04h */	int field_4;
-		/* 08h */	int field_8;
-		/* 0Ch */	int field_C;
-		/* 10h */	int field_10;
-		/* 14h */	int field_14;
+		/* 04h */	cTerrainSphereQuad* mpParent;
+		/* 08h */	cTerrainSphereQuad* mpChildren[4];
 		/* 18h */	int mPlanetLODChunkRes;
 		/// Index of sphere quad, from 0 to 5
-		/* 1Ch */	int mIndex;
+		/* 1Ch */	int mFace;
 		// UV coords?
-		/* 20h */	Math::Vector2 field_20;
-		/* 28h */	Math::Vector2 field_28;
-		/* 30h */	float field_30;  // 1.0
+		/* 20h */	Math::Vector2 mFaceMin;
+		/* 28h */	Math::Vector2 mFaceMax;
+		/* 30h */	float mFaceScale;  // 1.0
 		/* 34h */	Math::Vector3 field_34;  // 0, 0, 1
 		/* 40h */	char padding_40[0x64 - 0x40];
 		/* 64h */	float field_64;
 		/* 68h */	float field_68;
 		/* 6Ch */	bool mIsLowRes;
 		/* 70h */	Math::BoundingBox mChunkBoundingBox;
-		/* 88h */	float field_88;
-		/* 8Ch */	float field_8C;
+		/* 88h */	float mMinH;
+		/* 8Ch */	float mMaxH;
 		/* 90h */	bool mMustUpdateVertexBuffer;
 		/* 91h */	bool mMustUpdateIndexBuffer;
 		/* 94h */	TerrainQuadMesh* mpMesh;
@@ -135,8 +142,7 @@ namespace Terrain
 		/* 9Ch */	int mWaterIndicesCount;
 		/* A0h */	int mWaterIndicesStart;
 		/* A4h */	TerrainTransform mTerrainTransform;
-		// 154h vector with struct of size 16 with pointer to cTerrainSphereDecal
-		/* 154h */	eastl::vector<int> field_154;
+		/* 154h */	eastl::vector<cTerrainSphereQuadDecal> mDecalList;
 		/* 168h */	int field_168;
 		/* 16Ch */	int field_16C;
 		/* 170h */	int field_170;

--- a/Spore ModAPI/Spore/Terrain/cTerrainStateMgr.h
+++ b/Spore ModAPI/Spore/Terrain/cTerrainStateMgr.h
@@ -110,23 +110,23 @@ namespace Terrain
 		{
 			TerrainTextures();
 
-			/// From texture `0x9D8D0398.rw4`
+			/// From texture `water_foamline.rw4`
 			/* 00h */	TexturePtr mpWaterFoamCutMap;
-			/// From texture `0x11B5EE6F.rw4`
+			/// From texture `PCAwater2_0.rw4`
 			/* 04h */	TexturePtr mpWaterPCAComponent0;
-			/// From texture `0x11B5EE6E.rw4`
+			/// From texture `PCAwater2_1.rw4`
 			/* 08h */	TexturePtr mpWaterPCAComponent1;
-			/// From texture `0x84613AC8.rw4`
+			/// From texture `packed_shannon_textures.rw4`
 			/* 0Ch */	TexturePtr mpTextureAboveDetail2;
-			/// From texture `0xC66C3FCD.rw4`
+			/// From texture `seabed_grand_shallow.rw4`
 			/* 10h */	TexturePtr mpTextureBelow;
 			/// From texture `lava_detail.rw4`
 			/* 14h */	TexturePtr mpLavaDetail;
 			/// From texture `lava_ramp.rw4`
 			/* 18h */	TexturePtr mpLavaRamp;
-			/// From texture `0xA5AB24F5.rw4`
+			/// From texture `packed_detail_texture_intertiling.rw4`
 			/* 1Ch */	TexturePtr mpIceDetailNear;
-			/// From texture `0x3CEF83D5.rw4`
+			/// From texture `ice_lowfrequency.rw4`
 			/* 20h */	TexturePtr mpIceDetailMid;
 			/// From texture `ice_ramp.rw4`
 			/* 24h */	TexturePtr mpIceRamp;
@@ -138,7 +138,7 @@ namespace Terrain
 			/* 30h */	TexturePtr mpAtmospherePackedCurves;
 			/// Texture created in code with ID `AboveColorRamp`
 			/* 34h */	TexturePtr mpAboveColorRamp;
-			/// From bitmap `0xC5D262E4.8bitImage`
+			/// From bitmap `biome_noise_modifier.8bitImage`
 			/* 38h */	ResourceObjectPtr mpAboveDetailNoise;
 			/// From bitmap `planet_color_ramps_dead.32bitImage`
 			/* 3Ch */	ResourceObjectPtr mpPlanetColorRampsDead;

--- a/Spore ModAPI/Spore/Terrain/cWeatherManager.h
+++ b/Spore ModAPI/Spore/Terrain/cWeatherManager.h
@@ -45,17 +45,17 @@ namespace Terrain
 		/* 1Ch */	IVisualEffectPtr mpHighAtmoEffect;
 		/* 20h */	IVisualEffectPtr mpLoopBoxAtmoEffect;
 		/* 24h */	IVisualEffectPtr mpLoopBoxGroundEffect;
-		/* 28h */	IVisualEffectPtr field_28;
-		/* 2Ch */	IVisualEffectPtr field_2C;
-		/* 30h */	IVisualEffectPtr field_30;
-		/* 34h */	IVisualEffectPtr field_34;
+		/* 28h */	IVisualEffectPtr mLoopBoxAmbientEffect;
+		/* 2Ch */	IVisualEffectPtr mLoopBoxStormEffect;
+		/* 30h */	IVisualEffectPtr mScreenAmbientEffect;
+		/* 34h */	IVisualEffectPtr mTransitionEffect;
 		/* 38h */	uint32_t mLowAtmoEffectID;
 		/* 3Ch */	uint32_t mMidAtmoEffectID;
 		/* 40h */	uint32_t mHighAtmoEffectID;
-		/* 44h */	uint32_t field_44;  // not initialized
+		/* 44h */	uint32_t mCurrentAmbientID;  // not initialized
 		/* 48h */	uint32_t mLoopBoxAtmoEffectID;
 		/* 4Ch */	uint32_t mLoopBoxGroundEffectID;
-		/* 50h */	uint32_t field_50;
+		/* 50h */	uint32_t mCurrentStormLoopboxID;
 		/* 54h */	uint32_t mColdStormLoopboxID;
 		/* 58h */	uint32_t mWarmStormLoopboxID;
 		/* 5Ch */	uint32_t mHotStormLoopboxID;
@@ -64,11 +64,11 @@ namespace Terrain
 		/* 68h */	uint32_t mAmbientLoopboxID;  // 0x39FAA0F in init method, depends on weatherAmbientLoopboxType
 		/* 6Ch */	uint32_t mHotAmbientEffectID;
 		/* 70h */	uint32_t mLavaAmbientEffectID;
-		/* 74h */	int field_74;
+		/* 74h */	uint32_t mCurrentStormEffectID;
 		/* 78h */	uint32_t mColdStormEffectID;
 		/* 7Ch */	uint32_t mWarmStormEffectID;
 		/* 80h */	uint32_t mHotStormEffectID;
-		/* 84h */	uint32_t field_84;
+		/* 84h */	uint32_t mCurrentLocalStormEffectID;
 		/* 88h */	uint32_t mColdLocalStormEffectID;
 		/* 8Ch */	uint32_t mWarmLocalStormEffectID;
 		/* 90h */	uint32_t mHotLocalStormEffectID;


### PR DESCRIPTION
Most are from Feb2008 `.pdb` symbols.